### PR TITLE
Add timing lookup

### DIFF
--- a/araproc/__init__.py
+++ b/araproc/__init__.py
@@ -39,6 +39,6 @@ except: # noqa: E722
 if success_flag_libFFT not in [0, 1]:
     raise ImportError("Failed to load libRootFftwWrapper.so")
 
-success_flag_FFTinclude = ROOT.gInterpreter.Declare(f'#include "s{os.environ.get("ARA_DEPS_INSTALL_DIR")}/include/FFTtools.h"')
+success_flag_FFTinclude = ROOT.gInterpreter.Declare(f'#include "{os.environ.get("ARA_DEPS_INSTALL_DIR")}/include/FFTtools.h"')
 if not success_flag_FFTinclude:
     raise ImportError("Including FFTtools.h failed. Stop all work!")

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -285,10 +285,10 @@ class StandardReco:
             The RF channel (0->16) about which you want information
         theta : float
             The theta value, in standard AraRoot RayTraceCorrelator interferometric coordinates, 
-            meaning theat [-90 -> 90, 0 = horizontal],  of the sky point you want looked up.
+            meaning theta [-90 -> 90, 0 = horizontal],  of the sky point you want looked up.
         phi : float
             The phi value, in standard AraRoot RayTraceCorrelator interferometric coordinates, 
-            meaning theat [-180 -> 180],  of the sky point you want looked up.
+            meaning phi [-180 -> 180],  of the sky point you want looked up.
         which_distance : str
             Because this is our standard reco set, you can choose between "nearby" (at the cal pulser distance),
             or "distant" (at 300 m).

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -95,7 +95,7 @@ for e in range(iter_start, iter_stop, 1):
         arrival_time = reco.lookup_arrival_time(channel = 0, 
                                                 theta = reco_results["pulser_v"]["theta"], 
                                                 phi = reco_results["pulser_v"]["phi"],
-                                                which_distance="distant",
+                                                which_distance="nearby",
                                                 solution=0,
                                                 )
         print(f"Arrival time at ch 0 is {arrival_time:.1f} ns")

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -85,10 +85,20 @@ for e in range(iter_start, iter_stop, 1):
         wave_bundle = d.get_waveforms(useful_event)
 
         # print the average snr across channels 
-        print(snr.get_avg_snr(wave_bundle))      
+        avg_snr = snr.get_avg_snr(wave_bundle, excluded_channels=d.excluded_channels)
+        print(f"The Average SNR is {avg_snr:.1f}")
  
         # run our standard suite of reconstructions
         reco_results = reco.do_standard_reco(wave_bundle)
+
+        # here's how we can lookup arrival times given a reconstructed direction
+        arrival_time = reco.lookup_arrival_time(channel = 0, 
+                                                theta = reco_results["pulser_v"]["theta"], 
+                                                phi = reco_results["pulser_v"]["phi"],
+                                                which_distance="distant",
+                                                solution=0,
+                                                )
+        print(f"Arrival time at ch 0 is {arrival_time:.1f} ns")
 
         # plot the waveforms
         dv.plot_waveform_bundle(wave_bundle, 


### PR DESCRIPTION
This adds a small helper function to `araproc.analysis.standard_reco` to lookup the arrival time at an antenna from the ray trace correlator table.