### PR TITLE
Max correlation and coordinates 

### DIFF
--- a/araproc/analysis/correlation.py
+++ b/araproc/analysis/correlation.py
@@ -1,0 +1,35 @@
+import ctypes
+
+def get_max_corr_and_coords(corr_map):
+    """
+    Finds the maximum correlation value in a single map and extracts the 
+    corresponding theta and phi.
+
+    Parameters
+    ----------
+    corr_map : ROOT.TH2D
+        A 2D histogram containing correlation values, where the axes represent
+        theta and phi angles.
+
+    Returns
+    -------
+    max_corr : float
+        The maximum correlation value in the map.
+    max_theta : float
+        The theta coordinate corresponding to the maximum correlation value.
+    max_phi : float
+        The phi coordinate corresponding to the maximum correlation value.
+    """
+    # Find the bin with the maximum correlation
+    max_bin = corr_map.GetMaximumBin()
+    binx = ctypes.c_int()
+    biny = ctypes.c_int()
+    binz = ctypes.c_int() # Unused but needed
+    corr_map.GetBinXYZ(max_bin, binx, biny, binz)
+
+    # Get the correlation value and corresponding theta, phi
+    max_corr = corr_map.GetBinContent(max_bin)
+    max_theta = corr_map.GetYaxis().GetBinCenter(biny.value)
+    max_phi = corr_map.GetXaxis().GetBinCenter(binx.value)
+
+    return max_corr, max_theta, max_phi


### PR DESCRIPTION
Added a function to calculate the max correlation and coordinates of a given sky map. I already tested it with:

```
# find the max correlation, and the corresponding theta and phi (also for the vpol map at the distance of the pulser)
max_corr, max_theta, max_phi = correlation.get_max_corr_and_coords(reco_results["pulser_v"]["map"])
print(f"Max correlation: {max_corr}, Theta: {max_theta}, Phi: {max_phi}")
```
Do we want to add the test in run_example.py?