### PR TITLE
fixing a small A1 stationID bug

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -78,7 +78,7 @@ class StandardReco:
         # so look that up
 
         self.calpulser_r_library = {
-            1 : "48.02",
+            100 : "48.02",
             2 : "42.86",
             3 : "41.08",
             4 : "52.60",


### PR DESCRIPTION
There was a minor A1 stationID issue in _standard_reco.py_ while loading timing tables using _calpulser_r_library_