### PR TITLE
Minimum correlation fraction depth

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -625,8 +625,6 @@ class StandardReco:
         # Get maximum correlation and threshold
         max_corr = float(corr_map.get("corr"))
         threshold_corr = fraction * max_corr
-        print("Max corr in map: ", max_corr)
-        print("Threshold corr: ", threshold_corr)
 
         # Access correlation map and radius
         hist = corr_map.get("map")
@@ -655,7 +653,6 @@ class StandardReco:
                     # Ensure min_depth does not exceed z_thresh
                     if depth > min_depth and depth <= z_thresh:
                         min_depth = depth
-                        print(f"Updated min_depth to {min_depth} Theta: {theta}, Corr: {corr_value}, Depth: {depth}")
 
         if min_depth == -float('inf'):
             raise RuntimeError("No depth meets the fractional correlation threshold within the z_thresh.")
@@ -694,13 +691,11 @@ class StandardReco:
             try:
                 # Use the existing function to find the minimum depth for this map
                 depth = self.min_frac_corr_depth(corr_map, fraction=fraction, z_thresh=z_thresh)
-                print(f"Map {idx}: depth = {depth}")
 
                 # Update min_depth if the current depth is shallower (closer to the surface)
                 if depth > min_depth:
                     min_depth = depth
                     min_depth_index = idx
-                    print(f"Updated min_depth to {min_depth} for map index {min_depth_index}")
 
             except RuntimeError as e:
                 print(f"Map {idx} did not meet the threshold: {e}")

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -417,11 +417,8 @@ class StandardReco:
             raise ValueError("Radius not found in corr_map.")
         radius = float(radius)
 
-        # Get antenna z-coordinates and calculate average
-        geom_tool = ROOT.AraGeomTool.Instance()
-        z_coords = [geom_tool.getStationInfo(self.station_id).getAntennaInfo(ant).antLocation[2] 
-                    for ant in range(self.num_channels)]
-        avg_z = sum(z_coords) / len(z_coords)
+        # Calculate average antenna z coordinates
+        _, _, avg_z = mu.calculate_avg_antenna_xyz(self.station_id, self.num_channels)
 
         # Check if surface is visible at the given radius
         if radius < (abs(avg_z) + z_thresh):
@@ -634,9 +631,7 @@ class StandardReco:
         radius = float(radius)
 
         # Calculate average antenna z-coordinate
-        geom_tool = ROOT.AraGeomTool.Instance()
-        avg_z = sum(geom_tool.getStationInfo(self.station_id).getAntennaInfo(ant).antLocation[2] 
-                    for ant in range(self.num_channels)) / self.num_channels
+        _, _, avg_z = mu.calculate_avg_antenna_xyz(self.station_id, self.num_channels)
 
         min_depth = -float('inf')  # Initialize to find the shallowest depth (least negative)
 

--- a/araproc/framework/map_utilities.py
+++ b/araproc/framework/map_utilities.py
@@ -1,4 +1,5 @@
 import ctypes
+import ROOT
 
 def get_corr_map_peak(the_map  = None):
         
@@ -32,3 +33,42 @@ def get_corr_map_peak(the_map  = None):
         peak_phi = the_map.GetXaxis().GetBinCenter(_peakPhi.value)
         peak_theta = the_map.GetYaxis().GetBinCenter(_peakTheta.value)
         return peak_corr, peak_phi, peak_theta
+
+def calculate_avg_antenna_xyz(station_id, num_channels):
+    """
+    Calculates the average x, y, and z coordinates of antennas for a given station.
+
+    Parameters
+    ----------
+    station_id : int
+        ID of the station from which to retrieve antenna information.
+    num_channels : int
+        Number of channels (antennas) at the station.
+
+    Returns
+    -------
+    avg_x : float
+        Average x-coordinate of the antennas at the specified station.
+    avg_y : float
+        Average y-coordinate of the antennas at the specified station.
+    avg_z : float
+        Average z-coordinate of the antennas at the specified station.
+    """
+    geom_tool = ROOT.AraGeomTool.Instance()
+    
+    # Initialize sums for x, y, and z coordinates
+    sum_x, sum_y, sum_z = 0.0, 0.0, 0.0
+    
+    # Sum up x, y, and z coordinates for all antennas
+    for ant in range(num_channels):
+        ant_info = geom_tool.getStationInfo(station_id).getAntennaInfo(ant).antLocation
+        sum_x += ant_info[0]
+        sum_y += ant_info[1]
+        sum_z += ant_info[2]
+    
+    # Calculate averages
+    avg_x = sum_x / num_channels
+    avg_y = sum_y / num_channels
+    avg_z = sum_z / num_channels
+    
+    return avg_x, avg_y, avg_z


### PR DESCRIPTION
This function calculates the minimum correlation fraction depth:

You can specify (1) a fraction of the peak correlation -default 60%- and (2) a threshold depth where the surface "starts" or "it's reached" - neg 10 m- by default. 

This function starts a 'min_depth' from a neg. infinity depth and replaces 'min_depth' when it finds a new depth (measured from the surface and not above the surface) with a correlation => max_corr * fraction. 