### PR TITLE
Add ability to auto load pedestals

### DIFF
--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -14,6 +14,7 @@ https://github.com/matplotlib/matplotlib/issues/20300.
 """
 import matplotlib # noqa : E402
 matplotlib.use("agg")
+__mplver = matplotlib.__version__ # this seems to fix a rare segfault (don't ask me...)
 
 def plot_waveform_bundle(
     waveform_dict = None,

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -121,5 +121,6 @@ def plot_skymap(the_map = None,
     ROOT.gPad.SetRightMargin(0.15) # make space for the z axis
     c.SaveAs(ouput_file_path)
     ROOT.gPad.SetRightMargin(0) # reset, so we don't affect settings globally
+    c.Close()
 
     del c

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -16,10 +16,9 @@ logging.getLogger().setLevel(logging.INFO)
 d = dataset.AnalysisDataset(
     station_id=5,
     path_to_data_file="/data/exp/ARA/2019/blinded/L1/ARA05/0701/run005626/event005626.root",
-    path_to_pedestal_file="/data/ana/ARA/ARA05PA/ARA05_pedestals/ped_full_values_A5_run005626.dat"
 )
 iter_start = 0
-iter_stop = 20700
+iter_stop = 200
 
 ################################################################
 ################################################################
@@ -38,14 +37,13 @@ iter_stop = 20700
 ################################################################
 ################################################################
 # uncomment this dataset loader to see a nice CW contaminated A2 event
+# (eventNumber 213179, which is TTree index 20695 in the burn sample file)
 ################################################################
 ################################################################
 
-# (eventNumber 213179, which is TTree index 20695 in the burn sample file)
 # d = dataset.AnalysisDataset(
 #     station_id = 2,
 #     path_to_data_file="/data/exp/ARA/2013/filtered/burnSample1in10/ARA02/root/run1548/event1548.root",
-#     path_to_pedestal_file="/cvmfs/ara.opensciencegrid.org/trunk/RHEL_7_x86_64/ara_build/share/araCalib/ATRI/araAtriStation2Pedestals.txt"
 # )
 # iter_start = 20690
 # iter_stop = 20700


### PR DESCRIPTION
Now that we have a common place in cvmfs for pedestal files, we can ask AraProc to load them for us automatically. The user can still override this by passing a pedestal file directly. But passing the pedestal file directly is no longer required.