### PR TITLE
Standard reco getter functions for correlation functions

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -183,7 +183,7 @@ class StandardReco:
 
         return cross_correlations
 
-    def do_standard_reco(self, waveform_bundle, event_number):
+    def do_standard_reco(self, wavepacket, event_number):
         
         """
         A function to do a standard set of reconstructions.
@@ -211,13 +211,19 @@ class StandardReco:
 
         Parameters
         ----------
-        waveform_bundle : dict
-            A dictionary of the 16 waveforms.
-            The key is the RF channel number.
-            The value is a TGraph.
-            There should be 16 entries, even if you don't intend to use all
-            16 traces in your interferometry.
-            The exclusions are handled further down under the excluded channels section.
+        wavepacket : dict
+            A dict with three entries:
+              "event" : int  
+                Event number
+              "waveforms" : dict
+                A dictionary of the 16 waveforms.
+                The key is the RF channel number.
+                The value is a TGraph.
+                There should be 16 entries, even if you don't intend to use all
+                16 traces in your interferometry.
+                The exclusions are handled further down under the excluded channels section.
+              "type" : string
+                Waveform type requested by which_trace
         event_number : int
             The number of the event corresponding to the traces in wave_bundle. Required
             to access event-specific information like the correlation functions.       
@@ -246,6 +252,9 @@ class StandardReco:
         """
 
         reco_results = {}
+
+        event_number = wavepacket["event"]
+        waveform_bundle = wavepackt["waveforms"]
 
         # update correlation functions if needed
         if(self.__latest_event_num != event_number):
@@ -420,7 +429,7 @@ class StandardReco:
                                                                                        )
         return arrival_time
 
-    def __get_correlation_function(self, ch1, ch2, event_number):
+    def __get_correlation_function(self, ch1, ch2, wavepacket):
         """
         Returns the correlation function for the channel pair ch1-ch2.
 
@@ -430,14 +439,25 @@ class StandardReco:
           Number of first channel in correlation pair.
         ch2 : int
           Number of second channel in correlation pair.
-        event_number : int
-          Number of event whose correlation function is being requested.
+        wavepacket : dict
+            A dict with three entries:
+              "event" : int  
+                Event number
+              "waveforms" : dict
+                Dict mapping RF channel ID to waveforms.
+                Keys are channel id (an integer)
+                Values are TGraphs
+              "type" : string
+                Waveform type requested by which_trace
 
         Returns
         -------
         corr_func : TGraph
           Cross-correlation function for requested channel pair.
         """
+
+        event_number = wavepacket["event"]
+        waveform_bundle = wavepacket["waveforms"]
 
         # update correlation functions if needed
         if(self.__latest_event_num != event_number):

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -172,14 +172,14 @@ class StandardReco:
         
         # set up the waveform map the way AraRoot wants it
         # as a std::map<int, TGraph*>
-        waveform_map = ROOT.std.map("int", "TGraph*")()
-        ROOT.SetOwnership(waveform_map, True)
+        wf_map = ROOT.std.map("int", "TGraph*")()
+        ROOT.SetOwnership(wf_map, True)
         for chan_i in waveform_bundle.keys():
-            waveform_map[chan_i] = waveform_bundle[chan_i]
+            wf_map[chan_i] = waveform_bundle[chan_i]
                 
         cross_correlations = self.rtc_wrapper.correlators["distant"].GetCorrFunctions(pairs, wf_map)
         
-        del waveform_map
+        del wf_map
 
         return cross_correlations
 
@@ -222,7 +222,7 @@ class StandardReco:
                 There should be 16 entries, even if you don't intend to use all
                 16 traces in your interferometry.
                 The exclusions are handled further down under the excluded channels section.
-              "type" : string
+              "trace_type" : string
                 Waveform type requested by which_trace
  
         Returns
@@ -251,15 +251,15 @@ class StandardReco:
         reco_results = {}
 
         event_number = wavepacket["event"]
-        waveform_bundle = wavepackt["waveforms"]
+        waveform_bundle = wavepacket["waveforms"]
 
         # update correlation functions if needed
         if(self.__latest_event_num != event_number):
           self.__latest_event_num = event_number
 
           # get the correlation functions
-          self.__corr_functions_v = __calculate_cross_correlations(waveform_bundle, self.pairs_v)
-          self.__corr_functions_h = __calculate_cross_correlations(waveform_bundle, self.pairs_h) 
+          self.__corr_functions_v = self.__calculate_cross_correlations(waveform_bundle, self.pairs_v)
+          self.__corr_functions_h = self.__calculate_cross_correlations(waveform_bundle, self.pairs_h) 
         
         # check the cal pulser in V
         pulser_map_v = self.rtc_wrapper.correlators["nearby"].GetInterferometricMap(
@@ -444,7 +444,7 @@ class StandardReco:
                 Dict mapping RF channel ID to waveforms.
                 Keys are channel id (an integer)
                 Values are TGraphs
-              "type" : string
+              "trace_type" : string
                 Waveform type requested by which_trace
 
         Returns
@@ -461,8 +461,8 @@ class StandardReco:
           self.__latest_event_num = event_number
 
           # get the correlation functions
-          self.__corr_functions_v = __calculate_cross_correlations(waveform_bundle, self.pairs_v)
-          self.__corr_functions_h = __calculate_cross_correlations(waveform_bundle, self.pairs_h) 
+          self.__corr_functions_v = self.__calculate_cross_correlations(waveform_bundle, self.pairs_v)
+          self.__corr_functions_h = self.__calculate_cross_correlations(waveform_bundle, self.pairs_h) 
 
         if(ch1//8 != ch2//8):
           raise Exception("Correlation functions only available for like-polarization channels. Abort.")

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -429,11 +429,9 @@ class StandardReco:
         # Vpols
         if(ch1//8 == 0):
           idx = get_pair_index(ch1, ch2, self.pairs_v)
-
           return self.__corr_functions_v[idx]
 
         idx = get_pair_index(ch1, ch2, self.pairs_h)
-    
         return self.__corr_functions_h[idx]
 
     def get_pair_index(self, ch1, ch2, pairs):
@@ -454,8 +452,6 @@ class StandardReco:
         idx : int
           Index corresponding to channel pair.
         """
-
-        
 
         for it in pairs:
           idx = it[0]

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -183,7 +183,7 @@ class StandardReco:
 
         return cross_correlations
 
-    def do_standard_reco(self, wavepacket, event_number):
+    def do_standard_reco(self, wavepacket):
         
         """
         A function to do a standard set of reconstructions.
@@ -224,9 +224,6 @@ class StandardReco:
                 The exclusions are handled further down under the excluded channels section.
               "type" : string
                 Waveform type requested by which_trace
-        event_number : int
-            The number of the event corresponding to the traces in wave_bundle. Required
-            to access event-specific information like the correlation functions.       
  
         Returns
         -------

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -730,7 +730,7 @@ class AnalysisDataset:
                 Dict mapping RF channel ID to waveforms.
                 Keys are channel id (an integer)
                 Values are TGraphs
-              "type" : string
+              "trace_type" : string
                 Waveform type requested by which_trace
         """
 
@@ -742,7 +742,7 @@ class AnalysisDataset:
 
         wavepacket = {}
         wavepacket["event"] = useful_event.eventNumber
-        wavepacket{"type"] = which_traces
+        wavepacket["trace_type"] = which_traces
 
         # first, get the standard calibrated waves
         cal_waves = {}

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -681,8 +681,8 @@ class AnalysisDataset:
         sim_info = self.__dataset_wrapper.get_sim_information(event_idx)
         return sim_info
 
-    def get_waveforms(self,
-                      useful_event = None,
+    def get_wavepacket(self,
+                      useful_event,
                       which_traces = "filtered"
                       ):
                      
@@ -722,10 +722,16 @@ class AnalysisDataset:
 
         Returns
         -------
-        waveforms : 
-            A dictionary, mapping RF channel ID to waveforms.
-            Keys are channel id (an integer)
-            Values are TGraphs
+        wavepacket : dict
+            A dict with three entries:
+              "event" : int  
+                Event number
+              "waveforms" : dict
+                Dict mapping RF channel ID to waveforms.
+                Keys are channel id (an integer)
+                Values are TGraphs
+              "type" : string
+                Waveform type requested by which_trace
         """
 
         if useful_event is None:
@@ -733,6 +739,10 @@ class AnalysisDataset:
 
         if which_traces not in ["calibrated", "interpolated", "dedispersed", "filtered"]:
             raise KeyError(f"Requested waveform treatment ({which_traces}) is not supported")
+
+        wavepacket = {}
+        wavepacket["event"] = useful_event.eventNumber
+        wavepacket{"type"] = which_traces
 
         # first, get the standard calibrated waves
         cal_waves = {}
@@ -747,7 +757,8 @@ class AnalysisDataset:
                 raise
         
         if which_traces == "calibrated":
-            return cal_waves
+            wavepacket["waveforms"] = cal_waves
+            return wavepacket
     
         # for anything else, we need interpolation
 
@@ -764,7 +775,8 @@ class AnalysisDataset:
         
         # if they wanted interpolated waves, just return those
         if which_traces == "interpolated":
-            return interp_waves
+            wavepacket["waveforms"] = interp_waves
+            return wavepacket
 
         # and if they want a dedispersed wave, do that too
         dedispersed_waves = {}
@@ -782,7 +794,8 @@ class AnalysisDataset:
                 raise
         
         if which_traces == "dedispersed":
-            return dedispersed_waves
+            wavepacket["waveforms"] = dedispersed_waves
+            return wavepacket
     
         # and if they want filtered waves
         filtered_waves = cwf.apply_filters(self.__cw_filters, dedispersed_waves)
@@ -826,4 +839,5 @@ class AnalysisDataset:
         #     filtered_waves[chan_key] = filt_graph
 
         if which_traces == "filtered":
-            return filtered_waves
+            wavepacket["waveforms"] = filtered_waves
+            return wavepacket

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -87,7 +87,9 @@ for e in range(iter_start, iter_stop, 1):
         print(f"The Average SNR is {avg_snr:.1f}")
  
         # run our standard suite of reconstructions
-        reco_results = reco.do_standard_reco(wave_bundle)
+        reco_results = reco.do_standard_reco(wave_bundle, useful_event.eventNumber)
+
+        pair_idx = reco.get_pair_index(1, 2, reco.pairs_v)
 
         # here's how we can lookup arrival times given a reconstructed direction
         arrival_time = reco.lookup_arrival_time(channel = 0, 

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -80,7 +80,8 @@ for e in range(iter_start, iter_stop, 1):
       
         # by default, you get all the bells and whistles
         # (interpolated, dedispersed, cw filtered, and bandpassed)
-        wave_bundle = d.get_waveforms(useful_event)
+        wavepacket = d.get_wavepacket(useful_event)
+        wave_bundle = wavepacket["waveforms"]
 
         # print the average snr across channels 
         avg_snr = snr.get_avg_snr(wave_bundle, excluded_channels=d.excluded_channels)

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -88,7 +88,7 @@ for e in range(iter_start, iter_stop, 1):
         print(f"The Average SNR is {avg_snr:.1f}")
  
         # run our standard suite of reconstructions
-        reco_results = reco.do_standard_reco(wave_bundle, useful_event.eventNumber)
+        reco_results = reco.do_standard_reco(wavepacket)
 
         pair_idx = reco.get_pair_index(1, 2, reco.pairs_v)
 


### PR DESCRIPTION
This pull request is aimed at helping merge the csw and corr_snr functions into standard_reco.

Cached correlation functions in `StandardReco` object as private variables. Added a private getter function for correlation functions and a public function to look up index of channel pairs. 