### PR TITLE
Updating A1 RF and Soft trigger readout blocks for all configs

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -7,8 +7,8 @@ station100:
       filt3 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
       filt4 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
     readout_limits:
-      rf_readout_limit: 28
-      soft_readout_limit: 10
+      rf_readout_limit: 26
+      soft_readout_limit: 8
   config2:
     excluded_channels : []
     filters:
@@ -17,8 +17,8 @@ station100:
       filt3 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
       filt4 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
     readout_limits:
-      rf_readout_limit: 28
-      soft_readout_limit: 10
+      rf_readout_limit: 26
+      soft_readout_limit: 8
   config3:
     excluded_channels : []
     filters:
@@ -28,7 +28,7 @@ station100:
       filt4 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
     readout_limits:
       rf_readout_limit: 28
-      soft_readout_limit: 10
+      soft_readout_limit: 8
   config4:
     excluded_channels : []
     filters:
@@ -38,7 +38,7 @@ station100:
       filt4 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
     readout_limits:
       rf_readout_limit: 28
-      soft_readout_limit: 10
+      soft_readout_limit: 8
 station2:
   config1:
     excluded_channels : [15] # always exclude channel 15


### PR DESCRIPTION
here are the rf and soft trigger blocks for A1. config 1 runs are mostly all software triggers. therefore, the rf trigger block numbers are not necessary there and in this plot are simply copied from 2015-2016 run config for completeness.

[Full_Detector_Blocks_new.pdf](https://github.com/user-attachments/files/17548642/Full_Detector_Blocks_new.pdf)
![Full_Detector_Blocks_new](https://github.com/user-attachments/assets/c37265fa-5694-4d27-91a5-bb2f7c5b7e76)