### PR TITLE
update excluded channel treatment

### DIFF
--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -570,6 +570,14 @@ class AnalysisDataset:
         which, except for getting the "is_simulation" flag right.
     excluded_channels : array of ints
         A list of the RF channels you want excluded from the analysis
+    exluded_channels_and_vpol: array of ints
+        The excluded_channel list, plus channels 0->7 (inclusive).
+        This list can be used to calculate hpol only variables, so you get e.g.
+        bad channels and the exclusion of the vpol channels.
+    exluded_channels_and_hpol: array of ints
+        The excluded_channel list, plus channels 8->15 (inclusive).
+        This list can be used to calculate pol only variables, so you get e.g.
+        bad channels and the exclusion of the hpol channels.
     """
 
     def __init__(self, 
@@ -592,9 +600,11 @@ class AnalysisDataset:
         self.interp_tstep = None
         self.__dataset_wrapper = None
         self.excluded_channels = None
+        self.excluded_channels_and_hpol = None
+        self.excluded_channels_and_vpol = None
 
         self.num_rf_channels = 16 # hard coded, but a variable
-        self.rf_channel_indices = np.arange(0, self.num_rf_channels).tolist() # make indices
+        self.rf_channel_indices = const.rf_channels_ids
 
         if (interp_tstep < 0) or not np.isfinite(interp_tstep):
             raise ValueError(f"Something is wrong with the requested interpolation time step: {interp_tstep}")
@@ -641,7 +651,8 @@ class AnalysisDataset:
             raise
 
         self.excluded_channels = np.asarray(this_station_config["excluded_channels"])
-
+        self.excluded_channels_and_vpol = np.concatenate((self.excluded_channels, np.asarray(const.vpol_channel_ids)))
+        self.excluded_channels_and_hpol = np.concatenate((self.excluded_channels, np.asarray(const.hpol_channel_ids)))
         file.close()
 
     def __setup_bandpass_filters(self):


### PR DESCRIPTION
This creates a dataset object that contains the excluded channels (according to the yaml file), plus the hpols or the vpols. This way if you want to compute a vpol only variable, you can do like:
```
snr_vpol = snr.get_snr(wavebundle, excluded_channels = d.excluded_channels_and_hpol)
```