### PR TITLE
Updated timing table directories to temporary location.

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -114,12 +114,16 @@ class StandardReco:
         self.rtc_wrapper = interf.RayTraceCorrelatorWrapper(self.station_id)
 
         # always add a "nearby" correlator for 41m away
-        dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        #dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        dir_path = os.path.join("/mnt/stashcache/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables/Updated_Tables",
                                 f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{self.calpulser_r_library[station_id]}_angle_1.00_solution_0.root"
                                 )
-        ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        #ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        ref_path = os.path.join("/mnt/stashcache/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables/Updated_Tables",
                                 f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{self.calpulser_r_library[station_id]}_angle_1.00_solution_1.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "nearby",
@@ -129,12 +133,16 @@ class StandardReco:
                 )
 
         # always add a "distant" correlator for 300m away
-        dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        #dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        dir_path = os.path.join("/mnt/stashcache/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables/Updated_Tables",
                                 f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_300.00_angle_1.00_solution_0.root"
                                 )
-        ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        #ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
+        ref_path = os.path.join("/mnt/stashcache/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables/Updated_Tables",
                                 f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_300.00_angle_1.00_solution_1.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "distant",


### PR DESCRIPTION
Timing table directories switch to temporary location at `/mnt/stashcache/icecube/PUBLIC/groups/arasoft/raytrace_timing_tables/Updated_Tables` while we wait for permanent location to be updated.