### PR TITLE
Fix Occasional Sign Error in CSW Fine Tuning 

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -1060,10 +1060,15 @@ class StandardReco:
                     )
                 )
 
+                # AraRoot always compares channels with smaller IDs to channels with 
+                #   larger IDs but we always want to compare to the reference channel.
+                # Correct for this if the current ch_ID is larger than the reference ch_ID
+                reco_delay = reco_delays[ch_ID] if ch_ID<reference_ch else -1*reco_delays[ch_ID]
+
                 # Identify the `zoom_window` nanosecond window around the 
                 #   reconstructed delay
                 zoomed_indices = np.where(
-                    (np.abs( xcorr_times - reco_delays[ch_ID] )) < zoom_window // 2
+                    (np.abs( xcorr_times - reco_delay )) < zoom_window // 2
                 )[0]
 
                 # Calculate the time of maximum correlation from this

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -1063,12 +1063,13 @@ class StandardReco:
                 # AraRoot always compares channels with smaller IDs to channels with 
                 #   larger IDs but we always want to compare to the reference channel.
                 # Correct for this if the current ch_ID is larger than the reference ch_ID
-                reco_delay = reco_delays[ch_ID] if ch_ID<reference_ch else -1*reco_delays[ch_ID]
+                if ch_ID > reference_ch: 
+                    xcorr_times *= -1
 
                 # Identify the `zoom_window` nanosecond window around the 
                 #   reconstructed delay
                 zoomed_indices = np.where(
-                    (np.abs( xcorr_times - reco_delay )) < zoom_window // 2
+                    (np.abs( xcorr_times - reco_delays[ch_ID] )) < zoom_window // 2
                 )[0]
 
                 # Calculate the time of maximum correlation from this
@@ -1094,12 +1095,6 @@ class StandardReco:
                         np.argmax(xcorr_volts[zoomed_indices]) # index of max xcorr in zoomed array
                         + zoomed_indices[0] # Adjusted by first zoomed_index
                     ]
-
-            # AraRoot always compares channels with smaller IDs to channels with 
-            #   larger IDs but we always want to compare to the reference channel.
-            # Correct for this if the current ch_ID is larger than the reference ch_ID
-            if ch_ID > reference_ch: 
-                delay *= -1
             
             # Save the calculated arrival delay
             delays[ch_ID] = delay


### PR DESCRIPTION
For the CSW, for channels with a channel number greater than the reference channel, you need to multiply the time array of the cross correlation results by -1 so you're comparing the current channel's signal timing to the reference channel's timing, not vice versa. This is because AraRoot always calculated cross correlations by comparing lower numbered channels with respect to higher numbered channels. 

I accounted for this already when saving the fine-tuned arrival delay, but I neglected to consider this while using the reconstructed arrival time delays to fine tune the waveform shifting via cross correlation. So any CSW with a reference channel less than the number of total channels had a slightly odd CSW as a result. 

I ended up reformatting the handling of this to account for the sign flip right after the cross correlation is read in to reduce confusion about the two locations requiring a sign flip.