### PR TITLE
Fixing correlation SNR calculation

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -865,9 +865,9 @@ class StandardReco:
         corr_snr: float
            Channel pair correlation SNR.
         """
-
-        corr_func = self.__get_correlation_function(ch1, ch2, wave_packet, False)
-        corr_snr = snr.get_snr(corr_func)
+        
+        _, corr_func = wfu.tgraph_to_arrays(self.__get_correlation_function(ch1, ch2, wave_packet, False))
+        corr_snr = snr.get_snr(corr_func[abs(corr_func) > 0.001])
 
         return corr_snr
 

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -867,7 +867,16 @@ class StandardReco:
         """
         
         _, corr_func = wfu.tgraph_to_arrays(self.__get_correlation_function(ch1, ch2, wave_packet, False))
-        corr_snr = snr.get_snr(corr_func[abs(corr_func) > 0.001])
+
+        # trim correlation function 
+        corr_thresh = 1e-3
+        idxAboveThresh = np.squeeze(np.where(np.abs(corr_func) >= corr_thresh)) # all indices above threshold
+        idxFirst = idxAboveThresh[0] # first above threshold
+        idxLast = idxAboveThresh[-1] # last above threshold
+        corr_func = corr_func[idxFirst:idxLast+1] # trim to above threshold region
+ 
+        # calculate snr
+        corr_snr = snr.get_snr(corr_func)
 
         return corr_snr
 


### PR DESCRIPTION
Calling full phase correlation was returning correlation SNR with values `>10**15` due to near zero values in leading and trailing samples. Fixed it by removing those. Here is an example of trimmed (now) vs previous correlation function.
![corr_func](https://github.com/user-attachments/assets/8ca40922-f456-4682-81ae-41db5decb57c)
