### PR TITLE
Fixed CW removal

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -100,7 +100,7 @@ station2:
     excluded_channels : [15] # always exclude channel 15
     filters:
       filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
+      filt2 : { min_freq : 0.145, max_freq : 0.151, min_power_ratio : 0.02 }
       filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
       filt4 : { min_freq : 0.404, max_freq : 0.406, min_power_ratio : 0.02 }
     readout_limits:

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -610,6 +610,10 @@ class AnalysisDataset:
 
         if (interp_tstep < 0) or not np.isfinite(interp_tstep):
             raise ValueError(f"Something is wrong with the requested interpolation time step: {interp_tstep}")
+        if (interp_tstep < 0.3):
+            raise ValueError("Requested interpolation time step is <0.3 ns. SineSubtract has been found to give\n"
+                             "\t    incorrect/anomalous behavior for such small timesteps, and CW peaks are not properly\n"
+                             "\t    removed. Comment this warning if you want, but PROCEED WITH CAUTION.")
         self.interp_tstep = interp_tstep
 
         

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -584,7 +584,7 @@ class AnalysisDataset:
                  path_to_data_file : str,
                  station_id : int,
                  path_to_pedestal_file : str = None,
-                 interp_tstep : float = 0.25 ,
+                 interp_tstep : float = 0.5 ,
                  is_simulation : bool = False
                  ):
     
@@ -729,7 +729,6 @@ class AnalysisDataset:
                     These are dedispersed waves that are additionally
                     filtered of CW via the FFTtools SineSubtract filter.
                     They are then bandpass filtered to remove out of band noise.
-                    (Bandpass filtered temporarily turned off.)
                     Most people should use the "filtered" traces,
                     and so they are the default argument.
 


### PR DESCRIPTION
SineSubtract was not correctly removing CW from spectra. The exact cause of this is unclear, but is apparently related to the fact that the waveforms were upsampled to 0.25 ns. I have changed the interpolation timestep back to 0.5 ns to fix this. 

For posterity, I include some information about what we found to be happening. SineSubtract failed to remove CW peaks, despite the fact that it would find these peaks and seem to fit them with an appropriate amplitude. The reason for the non-removal was that the calculated power reduction ratio would be very small or _negative_. In other words, subtraction somehow resulted in power being _added_ to the spectrum. CW removal was seen to be successful for 0.3 ns timestep as well, but there was some evidence that it may have been less effective as the timestep was further reduced.

Below is a sample of this from SineSubtract's verbose output, as well as, the trace & spectrum that was input.

```
max_freq (ntries: 0 nattempts: 1): 79 0.146636
Guesses: f= 0.146636, A=450.180874, ph=(-0.94209721)Guess power is 121537.050905. Gradient is (27099281.827773,16766.306432,490.458670)
Minuit2Minimizer: Minimize with max-calls 545 convergence for edm < 0.01 strategy 1
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Power Ratio: -0.076167
max_freq (ntries: 1 nattempts: 2): 79 0.146636
Guesses: f= 0.146636, A=450.180874, ph=(-0.94209721)Guess power is 121537.050905. Gradient is (27099281.827773,16766.306432,490.458670)
Minuit2Minimizer: Minimize with max-calls 545 convergence for edm < 0.01 strategy 1
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Power Ratio: -0.076167
max_freq (ntries: 2 nattempts: 3): 79 0.146636
Guesses: f= 0.146636, A=450.180874, ph=(-0.94209721)Guess power is 121537.050905. Gradient is (27099281.827773,16766.306432,490.458670)
Minuit2Minimizer: Minimize with max-calls 545 convergence for edm < 0.01 strategy 1
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Power Ratio: -0.076167
max_freq (ntries: 3 nattempts: 4): 79 0.146636
Guesses: f= 0.146636, A=450.180874, ph=(-0.94209721)Guess power is 121537.050905. Gradient is (27099281.827773,16766.306432,490.458670)
Minuit2Minimizer: Minimize with max-calls 545 convergence for edm < 0.01 strategy 1
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 2231.2688170312681
Edm   = 1.69778880662444213e-06
Nfcn  = 72
f	  = 0.146615	 +/-  1.80823e-05	(limited)
phi0	  = -59.8511	 +/-  0.0354665
A0	  = 112.545	 +/-  0.0173354	(limited)
Power Ratio: -0.076167
[SineSubtract hits max number of failed attempts and moves on without subtracting peak.]
```
![image](https://github.com/user-attachments/assets/47017b86-d5a0-446b-9f43-6dd0b233500e)
![image](https://github.com/user-attachments/assets/a7ead779-b4ff-44cb-9ecb-61c8459168e3)
