### PR TITLE
Undo temporary timing table path fix

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -114,15 +114,13 @@ class StandardReco:
         self.rtc_wrapper = interf.RayTraceCorrelatorWrapper(self.station_id)
 
         # always add a "nearby" correlator for 41m away
-        #dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
-        dir_path = os.path.join("/data/ana/ARA/processing/support/raytrace_timing_tables/Updated_Tables",
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{self.calpulser_r_library[station_id]}_angle_1.00_solution_0.root"
+        dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{self.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
-        #ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
-        ref_path = os.path.join("/data/ana/ARA/processing/support/raytrace_timing_tables/Updated_Tables",
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{self.calpulser_r_library[station_id]}_angle_1.00_solution_1.root"
+        ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{self.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "nearby",
                 radius=float(self.calpulser_r_library[station_id]),
@@ -131,15 +129,13 @@ class StandardReco:
                 )
 
         # always add a "distant" correlator for 300m away
-        #dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
-        dir_path = os.path.join("/data/ana/ARA/processing/support/raytrace_timing_tables/Updated_Tables",
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_300.00_angle_1.00_solution_0.root"
+        dir_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_300.00_angle_1.00_solution_0_v2.root"
                                 )
-        #ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
-        #                        "PUBLIC/groups/arasoft/raytrace_timing_tables",
-        ref_path = os.path.join("/data/ana/ARA/processing/support/raytrace_timing_tables/Updated_Tables",
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_300.00_angle_1.00_solution_1.root"
+        ref_path = os.path.join("/cvmfs/icecube.osgstorage.org/icecube",
+                                "PUBLIC/groups/arasoft/raytrace_timing_tables",
+                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_300.00_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "distant",
                 radius=float(self.distant_events_r_library[1]),

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -104,10 +104,13 @@ for e in range(iter_start, iter_stop, 1):
         # plot the waveforms
         dv.plot_waveform_bundle(wave_bundle, 
                     time_or_freq="time",
-                    ouput_file_path=f"./station_{d.station_id}_run_{d.run_number}_event_{e}_waves.png",
+                    output_file_path=f"./station_{d.station_id}_run_{d.run_number}_event_{e}_waves.png",
                     )
         
         # and also plot one of the skymaps (in this case, the vpol map the distance of the pulser)
         dv.plot_skymap(reco_results["pulser_v"]["map"],
-                       ouput_file_path=f"./station_{d.station_id}_run_{d.run_number}_event_{e}_map.png",
+                       output_file_path=f"./station_{d.station_id}_run_{d.run_number}_event_{e}_map.png",
                        )
+
+
+


### PR DESCRIPTION
Updated timing table paths to their permanent locations. Also update `run_example.py` to fix typo that was fixed in [PR#58](https://github.com/ara-software/AraProc/pull/58).