### PR TITLE
Fast event idx lookup, dynamic spectrum range

### DIFF
--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -70,6 +70,7 @@ def plot_waveform_bundle(
                               layout="constrained")
 
     # draw the graphs, label each one appropriately
+    ymin = 1e100
     ymax = -1e100
     for wave_key in tgraphs_to_plot.keys():
         times, volts = wu.tgraph_to_arrays(tgraphs_to_plot[wave_key])
@@ -83,6 +84,7 @@ def plot_waveform_bundle(
             xvals = freqs*1e3 # from GHz to MHz
             yvals = 10*np.log10(np.abs(spectrum)**2 / 50 / 1e3) # from mV to dBm
 
+        ymin = min(ymin, yvals.min())
         ymax = max(ymax, yvals.max())
 
         axd[f"ch{wave_key}"].plot(xvals, yvals) # make the plot
@@ -96,7 +98,10 @@ def plot_waveform_bundle(
     
     # make limits look nice
     if time_or_freq == "freq":
-        ax.set_ylim([1,ymax+0.2])
+        # limit y range downwards
+        ymin = max(ymin, -25)
+
+        ax.set_ylim([ymin-5,ymax+5])
 
     # save figure
     fig.savefig(output_file_path)

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -80,7 +80,8 @@ def plot_waveform_bundle(
             # if they frequested frequency domain, do the FFT
             freqs, spectrum = wu.time2freq(times, volts)
             xvals = freqs
-            yvals = np.log10(np.abs(spectrum))
+            xvals = freqs*1e3 # from GHz to MHz
+            yvals = 10*np.log10(np.abs(spectrum)**2 / 50 / 1e3) # from mV to dBm
 
         ymax = max(ymax, yvals.max())
 

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -41,7 +41,7 @@ def plot_waveform_bundle(
 
     xlabel_options = {
         "time" : "Time (ns)",
-        "freq" : "Frequency (MHz)"
+        "freq" : "Frequency (GHz)"
     }
     ylabel_options = {
         "time" : "Voltage (mV)",
@@ -81,11 +81,10 @@ def plot_waveform_bundle(
             # if they frequested frequency domain, do the FFT
             freqs, spectrum = wu.time2freq(times, volts) # 'freqs' in 'GHz' and 'spectrum' (complex) in 'mV'
            
-            xvals = freqs*1e3 # from GHz to MHz
-            yvals = 10*np.log10(np.abs(spectrum)**2 / 50 / 1e3) # from mV to dBm
-
+            # Convert yvals to dBm
             # np.abs(spectrum)**2 makes spectrum in mV^2. For power, you do P = V^2/R , here R = Z_0 = 50 Ohm.
             # mV**2/50 =  mW * 1e-3. Power is always reperesented as dBm in dB scale which is 10*log10(P in mW)
+            yvals = 10*np.log10(np.abs(spectrum)**2 / 50 / 1e3) # from mV to dBm
 
         ymin = min(ymin, yvals.min())
         ymax = max(ymax, yvals.max())

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -70,6 +70,7 @@ def plot_waveform_bundle(
                               layout="constrained")
 
     # draw the graphs, label each one appropriately
+    ymax = -1e100
     for wave_key in tgraphs_to_plot.keys():
         times, volts = wu.tgraph_to_arrays(tgraphs_to_plot[wave_key])
         xvals = times
@@ -80,6 +81,8 @@ def plot_waveform_bundle(
             freqs, spectrum = wu.time2freq(times, volts)
             xvals = freqs
             yvals = np.log10(np.abs(spectrum))
+
+        ymax = max(ymax, yvals.max())
 
         axd[f"ch{wave_key}"].plot(xvals, yvals) # make the plot
         axd[f"ch{wave_key}"].set_title(f"Channel {wave_key}")
@@ -92,7 +95,7 @@ def plot_waveform_bundle(
     
     # make limits look nice
     if time_or_freq == "freq":
-        ax.set_ylim([1,4])
+        ax.set_ylim([1,ymax+0.2])
 
     # save figure
     fig.savefig(output_file_path)


### PR DESCRIPTION
Added fast event index lookup for a requested event number. This is more efficient than a for loop to find the ROOT file index corresponding to a given event number. Also made spectrum plots y range dynamic.

Finally, added some functionality for if we ever want to check the station id that's stored in the ROOT data (stored as a class variable `data_station_id`. In the ended I decided not to use it, but I already coded this up and maybe it will be useful later. Can remove if wanted.