### PR TITLE
Changing RF block length of A1 Config 1

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -12,7 +12,7 @@ station100:
       filt8 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
       filt9 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
     readout_limits:
-      rf_readout_limit: 26
+      rf_readout_limit: 20
       soft_readout_limit: 8
   config2:
     excluded_channels : []


### PR DESCRIPTION
Due to wrong RF block length setting (`rf_readout_limit: 26`) in A1 Config 1, more than 90% of RF and CP events were being flagged bad quality during L2 processing even if their waveform, although shorter, looked okay. That is because the actual length is 20 with time window size of 400 ns. I think, I will merge the change and reprocess Config 1 data. If there are questions/discussions, I will reopen the branch. 