### PR TITLE
Different AraSim and AraRoot path variables

### DIFF
--- a/araproc/__init__.py
+++ b/araproc/__init__.py
@@ -4,7 +4,7 @@ import os
 
 # libAraEvent
 try:
-    success_flag_libAraEvent = ROOT.gSystem.Load(os.environ.get("ARA_UTIL_INSTALL_DIR")+"/lib/libAraEvent.so")
+    success_flag_libAraEvent = ROOT.gSystem.Load(os.environ.get("ARA_ROOT_LIB_DIR")+"/libAraEvent.so")
 except: # noqa: E722
     logging.critical("Loading libAraEvent.so failed. Stop all work!")
     raise ImportError("Failed to load libAraEvent.so")
@@ -13,7 +13,7 @@ if success_flag_libAraEvent not in [0, 1]:
 
 # libAra (this is AraSim)
 try:
-    success_flag_libAra = ROOT.gSystem.Load(os.environ.get("ARA_UTIL_INSTALL_DIR")+"/lib/libAra.so")
+    success_flag_libAra = ROOT.gSystem.Load(os.environ.get("ARA_SIM_LIB_DIR")+"/libAra.so")
 except: # noqa: E722
     logging.critical("Loading libAra.so failed. Stop all work!")
     raise ImportError("Failed to load libAra.so")
@@ -23,7 +23,7 @@ if success_flag_libAra not in [0, 1]:
 
 # libAraCorrelator
 try:
-    success_flag_libAraCorrelator = ROOT.gSystem.Load(os.environ.get("ARA_UTIL_INSTALL_DIR")+"/lib/libAraCorrelator.so")
+    success_flag_libAraCorrelator = ROOT.gSystem.Load(os.environ.get("ARA_ROOT_LIB_DIR")+"/libAraCorrelator.so")
 except: # noqa: E722
     logging.critical("Loading libAraCorrelator.so failed. Stop all work!")
     raise ImportError("Failed to load libAraCorrelator.so")


### PR DESCRIPTION
Updated `__init__.py` to have different environmental variables to give the paths to the compiled AraSim and AraRoot libraries. New variables `ARA_ROOT_LIB_DIR` and `ARA_SIM_LIB_DIR` are meant to be descriptive and direct enough that unexpected directory structures can be accommodated without directly modifying `__init__.py`.

Users will need to add these variables to their environment for AraProc to work properly.