### PR TITLE
A1 cw filters

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -2,27 +2,25 @@ station100:
   config1:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.05 }
-      filt2 : { min_freq : 0.170, max_freq : 0.180, min_power_ratio : 0.05 }
+      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
+      filt2 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
       filt3 : { min_freq : 0.223, max_freq : 0.227, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.470, max_freq : 0.480, min_power_ratio : 0.02 }
-      filt8 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
-      filt9 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.245, max_freq : 0.280, min_power_ratio : 0.02 }
+      filt5 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
+      filt6 : { min_freq : 0.470, max_freq : 0.580, min_power_ratio : 0.02 }
+      filt7 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config2:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.05 }
-      filt2 : { min_freq : 0.170, max_freq : 0.180, min_power_ratio : 0.05 }
+      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
+      filt2 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
       filt3 : { min_freq : 0.223, max_freq : 0.227, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.245, max_freq : 0.280, min_power_ratio : 0.02 }
       filt5 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
+      filt6 : { min_freq : 0.470, max_freq : 0.580, min_power_ratio : 0.02 }
       filt7 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
@@ -30,15 +28,13 @@ station100:
   config3:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.05 }
-      filt2 : { min_freq : 0.170, max_freq : 0.180, min_power_ratio : 0.05 }
+      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
+      filt2 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
       filt3 : { min_freq : 0.223, max_freq : 0.227, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.245, max_freq : 0.300, min_power_ratio : 0.01 }
       filt5 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.570, max_freq : 0.580, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.143, max_freq : 0.151, min_power_ratio : 0.001 }
-      filt8 : { min_freq : 0.290, max_freq : 0.297, min_power_ratio : 0.001 }
-      filt9 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.470, max_freq : 0.580, min_power_ratio : 0.02 }
+      filt7 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 8

--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -2,39 +2,36 @@ station100:
   config1:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
+      filt1 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
       filt3 : { min_freq : 0.223, max_freq : 0.227, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.245, max_freq : 0.280, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.245, max_freq : 0.580, min_power_ratio : 0.02 }
       filt5 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.470, max_freq : 0.580, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config2:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
+      filt1 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
       filt3 : { min_freq : 0.223, max_freq : 0.227, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.245, max_freq : 0.280, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.245, max_freq : 0.580, min_power_ratio : 0.02 }
       filt5 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.470, max_freq : 0.580, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
   config3:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
+      filt1 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.122, max_freq : 0.126, min_power_ratio : 0.02 }
       filt3 : { min_freq : 0.223, max_freq : 0.227, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.245, max_freq : 0.300, min_power_ratio : 0.01 }
-      filt5 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.470, max_freq : 0.580, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.50, max_freq : 0.950, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.396, max_freq : 0.410, min_power_ratio : 0.02 }
+      filt5 : { min_freq : 0.245, max_freq : 0.580, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.140, max_freq : 0.160, min_power_ratio : 0.01 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 8

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -126,7 +126,7 @@ def plot_skymap(st,list_of_landmarks = None,cal_pulse_index = None,spice_depth =
     ----------
     list_of_cal_pulser_indices : list ## example [0,1,2,3]
        which calpulsers you want to see in your skymap
-    list_of_landmarks: list ## example ['ICL',IC22S','SPT','IC1S','Spice','WT']
+    list_of_landmarks: list ## example ['ICL',IC22S','SPT','IC1S','SPIce','WT']
        which landmarks you want to see in your skymap
     spice_depth : int/float
        the depth of spice pulser ## example -1451.3
@@ -147,11 +147,12 @@ def plot_skymap(st,list_of_landmarks = None,cal_pulse_index = None,spice_depth =
         raise TypeError("Path to output file must be a string")
    
     corr_peak, peak_phi, peak_theta = mu.get_corr_map_peak(the_map)
-    the_map.SetTitle(f"Peak Phi/Theta/Corr = {peak_phi:.1f}/ {peak_theta:.1f}/ {corr_peak:.2f}")
-    the_map.GetXaxis().SetTitle("Phi (deg)")
-    the_map.GetYaxis().SetTitle("Theta (deg)")
+    the_map.SetTitle(f"Peak #phi/#theta/Corr = {peak_phi:.1f}^{{o}}/ {peak_theta:.1f}^{{o}}/ {corr_peak:.2f}")
+    the_map.GetXaxis().SetTitle("Azimuth, #phi (^{o})")
+    the_map.GetYaxis().SetTitle("Elevation, #theta (^{o})")
     the_map.GetZaxis().SetTitle("Correlation")
-   
+    ROOT.gStyle.SetTitleFontSize(0.04)
+ 
     the_map.GetZaxis().SetRangeUser(0, corr_peak)
     the_map.GetXaxis().CenterTitle(1)
     the_map.GetYaxis().CenterTitle(1)
@@ -174,7 +175,7 @@ def plot_skymap(st,list_of_landmarks = None,cal_pulse_index = None,spice_depth =
            horizontal_line.SetLineStyle(2)  # Dashed line
            horizontal_line.SetLineWidth(2)
            horizontal_line.Draw("SAME")
-           label1 = ROOT.TLatex(150,  critical_ang + 5, "critical angle")  # Offset for clarity
+           label1 = ROOT.TLatex(150,  critical_ang + 5, "#theta_{c}")  # Offset for clarity
            label1.SetTextColor(ROOT.kRed)
            label1.SetTextSize(0.03)
            label1.Draw("SAME")
@@ -193,24 +194,24 @@ def plot_skymap(st,list_of_landmarks = None,cal_pulse_index = None,spice_depth =
         markers.append(marker)
 
         # Draw the label
-        if entry in ['IC1S', 'SPT','CP1','CP3']:
-           offset = 4 
+        if entry in ['IC1S','SPT','CP1','CP3']:
+           offset = 5 
         else:
-           offset = -4
+           offset = -5
         label = ROOT.TLatex(phi + offset, theta - offset, entry)  # Offset for clarity
-        label.SetTextColor(ROOT.kWhite)
+        label.SetTextColor(ROOT.kMagenta)
         label.SetTextSize(0.02)
         label.Draw("SAME")
         labels.append(label)
 
         if entry == "ICL":
            vertical_line = ROOT.TLine(phi, -90, phi, 90)  # Draw line from theta=-90 to theta=90
-           vertical_line.SetLineColor(ROOT.kBlue)
+           vertical_line.SetLineColor(ROOT.kCyan)
            vertical_line.SetLineStyle(2)  # Dashed line
            vertical_line.SetLineWidth(2)
            vertical_line.Draw("SAME")
-           label = ROOT.TLatex(phi + 2, theta + 30, "SP direction")  # Offset for clarity
-           label.SetTextColor(ROOT.kBlue)
+           label = ROOT.TLatex(phi + 2, theta + 30, "#phi_{SP}")  # Offset for clarity
+           label.SetTextColor(ROOT.kCyan)
            label.SetTextSize(0.03)
            label.Draw("SAME")
            labels.append(label)

--- a/araproc/framework/map_utilities.py
+++ b/araproc/framework/map_utilities.py
@@ -196,7 +196,7 @@ class AraGeom:
         pulser_name: str
           IC1S : IceCube 1S pulser
           IC22S : IceCube 22S pulser
-          Spice : Spicecore pulser
+          SPIce : South Pole IceCore pulser
         northing:
           The northing coordiates from surveyour's note in feets
 
@@ -206,14 +206,14 @@ class AraGeom:
           X, Y, Z location of pulser in station centric
         """
 
-        if pulser_name == "Spice" and spice_depth is None:
-            raise ValueError(f"Unknown Spice pulser depth")
+        if pulser_name == "SPIce" and spice_depth is None:
+            raise ValueError(f"Unknown SPIce pulser depth")
         pulser_coords = {
             "IC1S": [45659.6457, 50490.4199],
             "IC22S": [44884.416, 51444.8819],
-            "Spice": [42600, 48800],
+            "SPIce": [42600, 48800],
         }
-        pulser_depths = {"IC1S": -1400, "IC22S": -1450.47, "Spice": spice_depth}
+        pulser_depths = {"IC1S": -1400, "IC22S": -1450.47, "SPIce": spice_depth}
         if pulser_name not in pulser_coords:
             raise ValueError(f"Unknown pulser name: {pulser_name}")
 
@@ -280,7 +280,7 @@ class AraGeom:
         ----------
         list_of_cal_pulser_indices : list ## example [0,1,2,3]
           which calpulsers you want to see in your skymap
-        list_of_landmarks: list ## example ['ICL','IC22S','SPT','IC1S','Spice','WT']
+        list_of_landmarks: list ## example ['ICL','IC22S','SPT','IC1S','SPIce','WT']
           which landmarks you want to see in your skymap
         spice_depth : int/float
           the depth of spice pulser ## example -1451.3 
@@ -300,7 +300,7 @@ class AraGeom:
         elif list_of_cal_pulser_indices == ['all']:
              list_of_cal_pulser_indices = [0,1,2,3]
         if spice_depth is not None:
-           list_of_landmarks.append('Spice')
+           list_of_landmarks.append('SPIce')
         collect = {}
         
         calpulser = self.get_local_CP(list_of_cal_pulser_indices)
@@ -311,7 +311,7 @@ class AraGeom:
             del rCal, tCal, pCal
         del calpulser
           
-        for pulser in ["IC1S", "IC22S", "Spice"]:
+        for pulser in ["IC1S", "IC22S", "SPIce"]:
             if pulser in list_of_landmarks:
                 this_pulser = self.get_distant_pulsers(pulser, spice_depth)
                 r, t, p = self.get_relative_cartesian_to_spherical(station_center, this_pulser)


### PR DESCRIPTION
A1 sees three most prominent CWs at 123, 224 and 403 MHz. I added three filters in narrow band to remove those (3 filters). Calibration seasons (and also sporadically in Polar winter) have frequencies in 147, 152, 275, 280, 475, 807 MHz. I clustered the other in 3 filters. Last one filter was added for entire bandwidth (50-950 MHz) to catch and remove any missed CWs. Shortening the list further is hard as the min_pow_ratio is hard to estimates for a larger bandwidth. In general, A1 being shallower, sees more CWs! 