### PR TITLE
Fix get_corr_snr to handle empty corr. thresh cases

### DIFF
--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -886,6 +886,10 @@ class StandardReco:
         # trim correlation function 
         corr_thresh = 1e-3
         idxAboveThresh = np.squeeze(np.where(np.abs(corr_func) >= corr_thresh)) # all indices above threshold
+
+        # checking if idxAboveThresh is empty, if yes, just return 0 
+        if idxAboveThresh.size == 0:  # idxAboveThresh is empty
+            return 0
         idxFirst = idxAboveThresh[0] # first above threshold
         idxLast = idxAboveThresh[-1] # last above threshold
         corr_func = corr_func[idxFirst:idxLast+1] # trim to above threshold region

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -887,7 +887,7 @@ class StandardReco:
         corr_thresh = 1e-3
         idxAboveThresh = np.squeeze(np.where(np.abs(corr_func) >= corr_thresh)) # all indices above threshold
 
-        # checking if idxAboveThresh is empty, if yes, just return 0 
+        # check if there are no above threshold indices, if so return 0
         if idxAboveThresh.size == 0:  # idxAboveThresh is empty
             return 0
         idxFirst = idxAboveThresh[0] # first above threshold


### PR DESCRIPTION
Changed the  get_corr_snr to check if index above threshold is empty. If yes, just return 0
