### PR TITLE
Fixed some ROOT nonsense.

### DIFF
--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -529,7 +529,7 @@ class SimWrapper:
         ROOT.gSystem.RedirectOutput("/dev/null");
         self.sim_settings_tree.Scan("DETECTOR_STATION_LIVETIME_CONFIG")
         self.config = int(self.settings_ptr.DETECTOR_STATION_LIVETIME_CONFIG)
-        ROOT.gSystem.RedirectOutput(0,0);
+        ROOT.gROOT.ProcessLine("gSystem->RedirectOutput(0);")
 
     def __check_event_idx_sanity(self, event_idx):
         if event_idx is None:

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -625,7 +625,6 @@ class SimWrapper:
         """
 
         self.__check_event_idx_sanity(event_idx)
-        print(self.sim_tree.GetEntries())
     
         try:
             self.sim_tree.GetEntry(event_idx)


### PR DESCRIPTION
Redirecting output back to stdout and stderr was crashing for some reason. This should fix it. Not sure why it didn't always seem to break. 

Reference: [https://root-forum.cern.ch/t/how-to-invoke-gsystem-redirectoutput-0/14101](https://root-forum.cern.ch/t/how-to-invoke-gsystem-redirectoutput-0/14101)