### PR TITLE
Crop waveforms functions

### DIFF
--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -857,7 +857,7 @@ class AnalysisDataset:
                     These are filtered waveforms that are cropped to a time range
                     passed by the user through the crop_times argument. Outside this
                     range the waveform is set to 0. 
-        crop_times : dict of float pairs
+        crop_times : dict of float pairs (keys : int, channel number; values : tuple, time range)
             The time range (tmin, tmax) which traces should be cropped to for each channel. 
             To avoid cropping you can set tmin/tmax to a very negative/positive number. If
             a channel is missing from the dictionary, it will be skipped in the cropping process.  


### PR DESCRIPTION
Adds `cropped` waveform type, whose use case is mostly to separate D & R signals. The cropping parameters are passed by users through the `crop_times` argument, which just zeros out the trace outside the passed window. This waveform type is the last to be applied in the layers of waveform processing in dataset.