### PR TITLE
Quick fix on event quality issue ( if event has not known trigger type, tag as bad event)

### DIFF
--- a/araproc/analysis/daq_quality_cut.py
+++ b/araproc/analysis/daq_quality_cut.py
@@ -55,6 +55,7 @@ def process_event_info(useful_event, station_id):
         trig_type = 0
     else:
        logger.error("__________________ Unknown trigger type for the event _______________________")  # error message
+       trig_type = None
     num_ddas = constants.num_dda 
     blk_len = read_win // num_ddas
 
@@ -236,6 +237,9 @@ def check_daq_quality(useful_event, station_id, config):
 
     # Extract necessary information from useful_event using the merged function
     num_ddas,blk_len, trig_type, irs_block_number, channel_mask = process_event_info(useful_event, station_id)
+    ## Make sure the event has known trigger type
+    if trig_type is None:
+       return True 
 
     # Get DAQ structure errors
     daq_errors = get_daq_structure_errors(num_ddas,blk_len, trig_type, irs_block_number, channel_mask)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1a9e3a0f-4ac9-4ff8-98f1-d38d02082ec7)
It will now skip events with unknown trigger type.