### PR TITLE
Update SineSubtract peak finding option

### DIFF
--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -60,7 +60,7 @@ def get_filters(station_id, analysis_config):
             the_filter.setVerbose(False)
             the_filter.setFreqLimits(config_settings["min_freq"], 
                                     config_settings["max_freq"])
-            the_filter.setPeakFindingOption(0) 
+            the_filter.setPeakFindingOption(0) # change to use global max as peak 
             ROOT.SetOwnership(the_filter, True) # give python full ownership
             cw_filters[filter_name] = the_filter
 

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -60,6 +60,7 @@ def get_filters(station_id, analysis_config):
             the_filter.setVerbose(False)
             the_filter.setFreqLimits(config_settings["min_freq"], 
                                     config_settings["max_freq"])
+            the_filter.setPeakFindingOption(0) 
             ROOT.SetOwnership(the_filter, True) # give python full ownership
             cw_filters[filter_name] = the_filter
 

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -60,7 +60,8 @@ def get_filters(station_id, analysis_config):
             the_filter.setVerbose(False)
             the_filter.setFreqLimits(config_settings["min_freq"], 
                                     config_settings["max_freq"])
-            the_filter.setPeakFindingOption(0) # change to use global max as peak 
+            #the_filter.setPeakFindingOption(0) # change to use global max as peak 
+            the_filter.setPeakFindingOption(3) # change to only consider peaks above baseline computed by a Savitzky Golay filter 
             ROOT.SetOwnership(the_filter, True) # give python full ownership
             cw_filters[filter_name] = the_filter
 


### PR DESCRIPTION
Old:
> Changed how SineSubtract determines which frequency has the peak power to simply use the global maximum (`GLOBALMAX` mode).

New: 
Changed how SineSubtract determines which frequency has the peak power to require that the peak be far enough over a baseline computed by a Savitzky Golay filter (`SAVGOLSUB` mode).

The rest of the discussion compares `NEIGHBORFACTOR` to `GLOBALMAX`. 

The default setting is `NEIGHBORFACTOR` which requires the candidate peak frequency to have an amplitude `1/0.15` times larger than either of its neighbors. If no candidate peak frequency satisfies this condition, the CW filtering terminates. This is a sort of safety measure to ensure it doesn't over subtract from the spectrum. However, in the case of ARA some CW features have enough width in the frequency binning that this prevents the peak from being fully subtracted. So this PR turns that feature off. However, this means that one needs to be careful that the minimum power ratios chosen to not result in over subtraction in the target band. An example is shown below.

Unfiltered waveform:
<img width="693" alt="Screenshot 2025-01-30 at 4 11 29 PM" src="https://github.com/user-attachments/assets/20879607-16e4-48f9-93da-fa174ded49c3" />

Waveform applying a 130-150 MHz filter and **minimum power ratio of 1e-9 with NEIGHBORFACTOR mode**
<img width="696" alt="Screenshot 2025-01-30 at 1 50 52 PM" src="https://github.com/user-attachments/assets/eb453a71-391f-42ba-b3ac-f690797079fe" />

Waveform applying a 130-150 MHz filter and **minimum power ratio of 1e-9 with GLOBALMAX mode**
<img width="694" alt="Screenshot 2025-01-30 at 4 22 49 PM" src="https://github.com/user-attachments/assets/5ded2a43-28e7-4900-a890-64cb49feb6b9" />

Waveform applying a 130-150 MHz filter and **minimum power ratio of 1e-3 with GLOBALMAX mode**
<img width="696" alt="Screenshot 2025-01-30 at 4 28 41 PM" src="https://github.com/user-attachments/assets/ea31c5f6-05b4-4ed3-94fe-1dfca023039d" />
