### PR TITLE
updated CDF calculation

### DIFF
--- a/araproc/analysis/impulsivity.py
+++ b/araproc/analysis/impulsivity.py
@@ -61,7 +61,7 @@ def get_cdf(trace):
     sorted_waveform = hilbert_envelope[clo_sort_idx]
 
     # Cumulative distribution function (CDF) calculation
-    cdf = np.cumsum(sorted_waveform)
+    cdf = np.cumsum(sorted_waveform**2)
     cdf /= np.max(cdf)
 
     t_frac = np.linspace(0, 1, len(cdf))


### PR DESCRIPTION
Updated calculation of normalized CDF in terms of power rather than amplitude of sorted Hilbert envelope. This increases the separation in CDF related variables of signal and noise. The CDF thus changes from here

<img width="1192" alt="Screenshot 2025-02-06 at 1 36 57 PM" src="https://github.com/user-attachments/assets/979fdfac-916c-44f0-9826-d304227ccac0" />

to here

<img width="1196" alt="Screenshot 2025-02-06 at 1 37 25 PM" src="https://github.com/user-attachments/assets/af370fd4-cab1-42c5-b104-4445bdd26e28" />

