### PR TITLE
Added real run number for simulations

### DIFF
--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -428,6 +428,9 @@ class SimWrapper:
         if '.run' not in path_to_data_file:
             self.run_number = -10 # if there's no file we will crash anyway
         else:
+            # arasim files come in the form /path/AraOut.[setupFile].run[runNo].root so first
+            # split on '.run' and grab the last element to get [runNo].root then split on
+            # '.root' and grab the first element to be left with [runNo]
             self.run_number = int(path_to_data_file.split('.run')[-1].split('.root')[0])
         self.station_id = None
         self.num_events = None

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -425,7 +425,10 @@ class SimWrapper:
         self.event_tree = None
         self.sim_tree = None
         self.sim_settings_tree = None
-        self.run_number = -10 # this doesn't make sense for AraSim
+        if '.run' not in path_to_data_file:
+            self.run_number = -10 # if there's no file we will crash anyway
+        else:
+            self.run_number = int(path_to_data_file.split('.run')[-1].split('.root')[0])
         self.station_id = None
         self.num_events = None
         self.config = None


### PR DESCRIPTION
Changed the run number for simulations from `-10` to the run number in the passed root file. This will help with analyzing simulations and finding bugs.

The parsing is pretty simple but should work based on how the AraSim generates output file names: https://github.com/ara-software/AraSim/blob/a10009706e1d9f256f7578d0eb98c9db6a9137d6/AraSim.cc#L198 (generally simulations we produce will always have `argc > 2` when running AraSim so that the run number is part of the file name)