### PR TITLE
Add support for filtering IDed CW

### DIFF
--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -117,6 +117,7 @@ def get_active_filters(cw_filters, cw_ids, chan):
         badFreqs = cw_ids[key]
 
         for freq in badFreqs:
+            freq /= 1e3 # convert to GHz
             for filter_i, filter in cw_filters.items():
                 # this filter is already activated
                 if filter_i in active_filters: 
@@ -130,7 +131,7 @@ def get_active_filters(cw_filters, cw_ids, chan):
                     active_filters[filter_i] = filter
 
     # filters are applied in order they appear in dict
-    # there's some advantage to apply the in order of descending 
+    # there's some advantage to apply them in order of descending 
     # min_power_ratio, so let's quickly enforce that
     active_filters = {k : v for k, v in sorted(active_filters.items(), key=lambda x: x[1]["min_power_ratio"])}
 

--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -117,7 +117,6 @@ def get_active_filters(cw_filters, cw_ids, chan):
         badFreqs = cw_ids[key]
 
         for freq in badFreqs:
-            freq /= 1e3 # convert to GHz
             for filter_i, filter in cw_filters.items():
                 # this filter is already activated
                 if filter_i in active_filters: 

--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -3,6 +3,8 @@ import ROOT
 import yaml
 import copy
 
+from araproc.framework import constants as const
+
 def apply_filters_one_channel(cw_filters, waveform_in):
     """
     Apply CW filters to a single waveform.
@@ -30,28 +32,33 @@ def apply_filters_one_channel(cw_filters, waveform_in):
 
     if len(cw_filters) > 0:
         for filter_i, filter in cw_filters.items():
-            local_waveform = filter.subtractCW(latest_waveform, -1)
+            local_waveform = filter["filter"].subtractCW(latest_waveform, -1)
             ROOT.SetOwnership(local_waveform, True) # take posession 
             del latest_waveform
             latest_waveform = local_waveform # update the latest waveform
     
     return latest_waveform
 
-def apply_filters(cw_filters, waveform_bundle):
+def apply_filters(cw_filters, waveform_bundle, cw_ids = None):
 
     """
     Apply CW filters to a bundle of waveforms.
 
     Parameters
     ----------
-    cw_filters : dictionary
-        A dictionary of sine subtract filters to be applied.
-        Key is a string, and is the name of the filter from the config file.
+    cw_filters : dictionary of dictionaries
+        A dictionary of sine subtract filters available to be applied.
+        First key is a string, and is the name of the filter from the config file.
+        Second key is the filter information, one of: ["filter", "min_freq", "max_freq", "min_power_ratio"]
         Value is the sine subtract filter to applied.
     waveform_bundle : dictionary
         A dictionary of waveforms to be processed.
         Key is channel id.
         Value is the TGraph to be filtered.
+    cw_ids : dictionary
+        A dictionary of cw id info.
+        If None, all set CW filters allowed to filter. Otherwise, only those 
+        covering frequencies in the cw id info will be allowed to filter.
 
     Returns
     -------
@@ -63,7 +70,69 @@ def apply_filters(cw_filters, waveform_bundle):
 
     filtered_waveforms = {}
     for ch_id, wave in waveform_bundle.items():
-        filtered_waveforms[ch_id] = apply_filters_one_channel(cw_filters, wave)
+
+        active_cw_filters = get_active_filters(cw_filters, cw_ids, ch_id)
+        filtered_waveforms[ch_id] = apply_filters_one_channel(active_cw_filters, wave)
 
 
     return filtered_waveforms
+
+def get_active_filters(cw_filters, cw_ids, chan):
+    """
+    Apply CW filters to a bundle of waveforms.
+
+    Parameters
+    ----------
+    cw_filters : dictionary
+        A dictionary of sine subtract filters available to be applied..
+        Key is a string, and is the name of the filter from the config file.
+        Value is the sine subtract filter to applied.
+    cw_ids : dictionary
+        A dictionary of cw id info.
+        If None, all available CW filters are activated. Otherwise, only those 
+        covering frequencies in the cw id info will be activated.
+    chan : int
+        Channel number which filters will be applied to.   
+ 
+    Returns
+    -------
+    active_filters : dictionary
+        A dictionary of sine subtract filters to be applied for this event and channel.
+    """
+
+    if cw_ids is None:
+        return cw_filters
+
+    active_filters = {}
+    
+    if chan in const.vpol_channel_ids:
+      pol = "v"
+    else: 
+      pol = "h"
+
+    scan_directions = ["fwd", "bwd"]
+    for direction in scan_directions:
+
+        key = f"badFreqs_{direction}_{pol}"
+        badFreqs = cw_ids[key]
+
+        for freq in badFreqs:
+            for filter_i, filter in cw_filters.items():
+                # this filter is already activated
+                if filter_i in active_filters: 
+                    continue
+
+                fmin = filter["min_freq"]
+                fmax = filter["max_freq"]
+       
+                # if filter covers this frequency, activate it 
+                if freq >= fmin and freq <= fmax: 
+                    active_filters[filter_i] = filter
+
+    # filters are applied in order they appear in dict
+    # there's some advantage to apply the in order of descending 
+    # min_power_ratio, so let's quickly enforce that
+    active_filters = {k : v for k, v in sorted(active_filters.items(), key=lambda x: x[1]["min_power_ratio"])}
+
+    return active_filters
+

--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -133,7 +133,7 @@ def get_active_filters(cw_filters, cw_ids, chan):
     # filters are applied in order they appear in dict
     # there's some advantage to apply them in order of descending 
     # min_power_ratio, so let's quickly enforce that
-    active_filters = {k : v for k, v in sorted(active_filters.items(), key=lambda x: x[1]["min_power_ratio"])}
+    active_filters = {k : v for k, v in sorted(active_filters.items(), key=lambda x: x[1]["min_power_ratio"], reverse=True)}
 
     return active_filters
 

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -341,7 +341,7 @@ class DataWrapper:
 
         # load up the cw id info
         self.cw_id_ptrs = {}
-        cw_id_info = ["badFreqs"] #, "badSigmas"]
+        cw_id_info = ["badFreqs", "badSigmas"]
         scan_directions = ["fwd", "bwd"]
         polarizations = ["v", "h"]
         for info in cw_id_info:
@@ -405,7 +405,7 @@ class DataWrapper:
         if self.cw_id_tree is not None:
             event_number = raw_event.eventNumber
             if self.cw_id_tree.GetEntryWithIndex(event_number) < 0:
-                logging.critical(f"Unable to get corresponding cw id entry for {event_number}.")
+                raise Exception(f"Unable to get corresponding cw id entry for {event_number}.")
         
         return raw_event
 
@@ -456,7 +456,7 @@ class DataWrapper:
         if self.cw_id_tree is not None:
             event_number = useful_event.eventNumber
             if self.cw_id_tree.GetEntryWithIndex(event_number) < 0:
-                logging.critical(f"Unable to get corresponding cw id entry for {event_number}.")
+                raise Exception(f"Unable to get corresponding cw id entry for {event_number}.")
  
         return useful_event
 

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -49,6 +49,20 @@ iter_stop = 200
 # iter_start = 20690
 # iter_stop = 20700
 
+################################################################
+################################################################
+# uncomment this one to see an example of CW removal using identified CW 
+################################################################
+################################################################
+
+# d = dataset.AnalysisDataset(
+#     station_id = 100,
+#     path_to_data_file="/data/ana/ARA/processing/data/10pct/L2/station_100/year_2020/station_100_run_00019706.root",
+#     path_to_cw_ids = "/home/brianclark/ARA/FiveStation/scripts/phase_var/CWID_station_100_run_19706.root",
+# )
+# iter_start = 0
+# iter_stop = d.num_events
+
 print(f"Config is {d.config}")
 print(f"Excluded channels are {d.excluded_channels}")
 


### PR DESCRIPTION
This PR adds functionality for users to pass a pre-calculated ROOT file containing IDed CW for events in a run. 

When a file is passed, CW filters specified in `analysis_configs.yaml` are only applied to a given event & polarization if an identified CW frequency is in their filtering band, otherwise no filtering is applied (NB even if a filter does contain an identified frequency, the spectral amplitude in the band must still meet the minimum power ratio criteria for the filter to subtract anything).

If no file is passed, the default behaviour is to apply all CW filters as has been done previously.

Additional filter information is now tracked since this information does not have getter functions and the relevant variables are private in the `SineSubtract` class.

Some important limitations to note in the current implementation:
- Applying IDed CW filtering to simulation events it not currently supported
- When IDed CW filtering is enabled it is not possible to _also_ apply a "blanket" CW filter for all events