### PR TITLE
Jackknife RMS

### DIFF
--- a/araproc/analysis/hilbert.py
+++ b/araproc/analysis/hilbert.py
@@ -27,7 +27,7 @@ def get_hilbert_snr(waveform):
     hill = wfu.get_hilbert_envelope(waveform)
     hill_max_idx = np.argmax(hill)
     hill_max = hill[hill_max_idx]
-    hill_rms = snr.get_min_segmented_rms(hill)
+    hill_rms = snr.get_jackknife_rms(hill)
 
     if(hill_rms == 0.0):
       return 0

--- a/araproc/analysis/rpr.py
+++ b/araproc/analysis/rpr.py
@@ -38,7 +38,7 @@ def get_rpr(waveform):
     max_val = channel_wf[max_bin]
 
     # Get noise rms from snr module
-    noise_sigma = snr.get_min_segmented_rms(channel_wf)
+    noise_sigma = snr.get_jackknife_rms(channel_wf)
 
     # Calculate and return the RPR value
     rpr_val = max_val / noise_sigma

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -162,7 +162,7 @@ def get_jackknife_rms(waveform, nSamples=50):
     subStd = np.sqrt((np.sum(np.square(allRms-subMean)) - np.square(allRms-subMean))/(nSegs-1.)) # std of all other all-but RMS values
     
     mask = (allRms >  subMean - subStd) # if all-but RMS isn't an outlier mark this segment to be included
-    mask = np.repeat(mask, nSamples)[:traceLen] # convert from the outlier mask array from being per-segment to per-sample
+    mask = np.repeat(mask, nSamples)[:traceLen] # convert the outlier mask array from being per-segment to per-sample
     
     # calculate RMS from non-outlier segments
     rms = np.sqrt(np.mean(trace2[mask]))   

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -68,6 +68,7 @@ def get_min_segmented_rms(waveform, nsegs=8):
 
       if(trace.ndim != 1):
         raise Exception("Trace is not 1d in snr.get_min_segmented_rms. Abort")
+
     else:
       raise Exception("Unsupported data type in snr.get_min_segmented_rms. Abort")
 
@@ -129,9 +130,10 @@ def get_jackknife_rms(waveform, nSamples=50):
       trace = np.squeeze(trace)
 
       if(trace.ndim != 1):
-        raise Exception("Trace is not 1d in snr.get_min_segmented_rms. Abort")
+        raise Exception("Trace is not 1d in snr.get_jackknife_rms. Abort")
+
     else:
-      raise Exception("Unsupported data type in snr.get_min_segmented_rms. Abort")
+      raise Exception("Unsupported data type in snr.get_jackknife_rms. Abort")
 
     # first split the trace into segments of nSamples 
     # then calculate the RMS on the trace _without_ that segment (ie the "all-but RMS")

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -140,15 +140,15 @@ def get_jackknife_rms(waveform, nSamples=50):
     allRms = []
     traceLen = len(trace)
     trace2 = np.square(trace)
-    trace2Sum = np.sum(trace2)
+    trace2Sum = np.sum(trace2) # sum of squares of full trace
     
     start_idx = np.arange(0, traceLen, nSamples)
     end_idx = np.clip(start_idx + nSamples, 0, traceLen)
     segLens = end_idx - start_idx     
     nSegs = len(segLens)
 
-    segTrace2Sum = np.array([np.sum(trace2[start:end]) for start, end in zip(start_idx, end_idx)])
-    allRms = np.sqrt((trace2Sum-segTrace2Sum)/(traceLen - segLens))
+    segTrace2Sum = np.array([np.sum(trace2[start:end]) for start, end in zip(start_idx, end_idx)]) # sum of squares in each segment
+    allRms = np.sqrt((trace2Sum-segTrace2Sum)/(traceLen - segLens)) # all-but rms is calculated from sum of full-trace squares _minus_ sum of segment-only squares
  
     # segments that have outlier (ie nonthermal) voltages, will have
     # an all-but RMS that is significantly smaller than others


### PR DESCRIPTION
This PR adds a sort-of jackknife estimate of the RMS of a trace and changes this to be the default RMS estimator in SNR calculations. The goal of this technique is both maximize the amount of the trace used to estimate the RMS and also be robust against impulsive signals in the trace. It does this by splitting the trace into segments and attempting to identify which segments are "outliers" in that they contain signal. It then calculates the RMS on all non-outlier segments in the trace. Segments are in terms of a fixed number of samples (to reduce sensitivity to the total trace length). By default 50 samples are used, corresponding to a 25 ns segment with our default 0.5 ns interpolation.

This new method has the advantage over our current estimate that it does not bias the RMS downwards (due to our current estimator being the `min` of segments' RMS) and results in a less dramatic difference RMS between RF triggers and software triggers (some difference is unavoidable, due to the significantly different trace lengths).

Below are some comparisons of the jackknife RMS compared to our current method, which splits the trace into `nsegs` equal-length segments and takes the minimum among these to be the RMS estimator. Comparisons are shown for `nsegs` values of 1 (the entire trace), 2, 4, 8 (default), and 16. All estimates are calculated for channel 0. 

Keep in mind that the current method always biases the RMS downwards.

**Example 1: A5 Run 5000 Event 1038 (CP trigger)**

```
nsegs = 1: 59.13
nsegs = 2: 43.91
nsegs = 4: 41.59
nsegs = 8: 39.73
nsegs = 16: 34.19
jackknife: 44.25
```

Jackknife matches well with `nsegs=2` which is the smallest number which would result in a signal-less segment.

<img width="691" alt="Screenshot 2025-03-01 at 2 09 46 AM" src="https://github.com/user-attachments/assets/6ce14412-9ecd-4188-9800-6422ab76667f" />

**Example 2: A5 Run 5000 Event 1044 (software trigger)**

```
nsegs = 1: 40.41
nsegs = 2: 39.30
nsegs = 4: 37.03
nsegs = 8: 33.95
nsegs = 16: 23.28
jackknife: 39.18
```

Note that the jackknife estimate is close to the `nsegs=1` estimate (essentially the true RMS in this case) and much less biased than the default `nsegs=8` estimate. Note that even the RMS of the full trace is slightly smaller than RF triggers due to the small number of samples.

<img width="692" alt="Screenshot 2025-03-01 at 2 10 44 AM" src="https://github.com/user-attachments/assets/09c0396e-99c6-4aa0-9aa4-6f43b8b507f0" />

**Example 3: A5 Run 5000 Event 1049 (RF trigger)**

```
nsegs = 1: 43.78
nsegs = 2: 42.45
nsegs = 4: 40.68
nsegs = 8: 39.99
nsegs = 16: 35.29
jackknife: 41.81
```

No really obvious signal exists here and jackknife agrees roughly with `nsegs=2`.

<img width="692" alt="Screenshot 2025-03-01 at 2 12 22 AM" src="https://github.com/user-attachments/assets/f5abd37c-0cda-44d0-9770-b3904e78ee42" />

**Example 4: A1 Run 16562 Event 8865 (RF trigger -- SPIce event)**

```
nsegs = 1: 36.92
nsegs = 2: 31.54
nsegs = 4: 20.50
nsegs = 8: 19.86
nsegs = 16: 18.99
jackknife: 24.30
```

Jackknife is slightly larger than `nsegs=4`, which is the smallest example which would result in a signal-less segment, avoiding both pulses.

<img width="694" alt="Screenshot 2025-03-01 at 2 15 31 AM" src="https://github.com/user-attachments/assets/79acea11-6214-4a32-9caf-d46bc0dc8d16" />


**Example 5: A1 Run 16562 Event 8817 (RF trigger)**

```
nsegs = 1: 20.22
nsegs = 2: 18.67
nsegs = 4: 17.87
nsegs = 8: 17.63
nsegs = 16: 16.70
jackknife: 18.91
```

Again, no really obvious signal exists here and jackknife agrees roughly with `nsegs=2`.

<img width="693" alt="Screenshot 2025-03-01 at 2 17 13 AM" src="https://github.com/user-attachments/assets/174b2c80-6700-430c-8a03-905f5fa4cccf" />
