### PR TITLE
improved peak-to-peak calculation

### DIFF
--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -45,11 +45,11 @@ def get_vpp(waveform, order = 1, use_local = True):
       return vpp
 
     # append 0 to the start and end of the trace to handle edge points in 'argrelextrema'
-    trace = np.pad(trace, (1, 1), mode = 'constant', constant_values = 0)
+    padded_trace = np.pad(trace, (1, 1), mode = 'constant', constant_values = 0)
 
     # find local extrema
-    upper_peak_idx = argrelextrema(trace, np.greater, order = order)[0]
-    lower_peak_idx = argrelextrema(trace, np.less, order = order)[0]
+    upper_peak_idx = argrelextrema(padded_trace, np.greater, order = order)[0]
+    lower_peak_idx = argrelextrema(padded_trace, np.less, order = order)[0]
 
     # combine and sort indices (using np.unique)
     peak_idx = np.unique(np.concatenate((upper_peak_idx, lower_peak_idx)))

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -4,7 +4,7 @@ from scipy.signal import argrelextrema
 
 from araproc.framework import waveform_utilities as wfu
 
-def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5):
+def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5, time = None):
 
     """ 
     Calculates the peak-to-peak voltage of a signal using local (Default) and global extrema.
@@ -22,6 +22,8 @@ def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5):
         Time window in nanoseconds to calculate the peak-to-peak voltage.
     dt : float, optional (Default = 0.5 ns)
         Sampling interval in nanoseconds for synthetic time array.
+    time : np.ndarray, optional (Default = None)
+        Optional time array to use for waveform. If None, synthetic time will be created.
 
     Returns
     -------
@@ -43,9 +45,13 @@ def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5):
       if(trace.ndim != 1):
         raise Exception("Trace is not 1d in snr.get_vpp. Abort")
 
-      # create synthetic time array based on dt = 0.5 ns
-      time = np.arange(len(trace)) * dt
-      
+      # use provided time or create synthetic time if not given
+      if time is None:
+        time = np.arange(len(trace)) * dt
+      else:
+        if len(trace) != len(time):
+          raise ValueError("Provided time array must match trace length.")
+
     else:
       raise Exception("Unsupported data type in snr.get_vpp. Abort")
 

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -4,15 +4,15 @@ from scipy.signal import argrelextrema
 
 from araproc.framework import waveform_utilities as wfu
 
-def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5, time = None):
+def get_vpp(waveform, order = 1, use_local = True, time_window = 20):
 
     """ 
     Calculates the peak-to-peak voltage of a signal using local (Default) and global extrema.
 
     Parameters
     ----------
-    waveform: TGraph or np.ndarray
-        A TGraph or np.ndarray of the waveform voltage.
+    waveform: ROOT.TGraph, tuple, or list
+        A TGraph or a tuple/list containing two np.ndarrays: (time, trace).
     order : int, optional (Default = 1)
         How many points on each side to compare for finding extrema.
     use_local: bool, optional (Default = True)
@@ -20,10 +20,6 @@ def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5, t
         If False, returns the peak-to-peak voltage based on global extrema.
     time_window: float, optional (Default = 20 ns)
         Time window in nanoseconds to calculate the peak-to-peak voltage.
-    dt : float, optional (Default = 0.5 ns)
-        Sampling interval in nanoseconds for synthetic time array.
-    time : np.ndarray, optional (Default = None)
-        Optional time array to use for waveform. If None, synthetic time will be created.
 
     Returns
     -------
@@ -34,23 +30,16 @@ def get_vpp(waveform, order = 1, use_local = True, time_window = 20, dt = 0.5, t
     if(isinstance(waveform, ROOT.TGraph)):
       time, trace = wfu.tgraph_to_arrays(waveform)
       if len(trace) != len(time):
-        raise ValueError("Waveform and time must have the same length.")
+        raise ValueError("Trace and time must have the same length.")
 
-    elif(isinstance(waveform, np.ndarray)):
-      trace = np.copy(waveform)
-      
-      # don't be bothered by some unused dimensions
-      trace = np.squeeze(trace)
-
-      if(trace.ndim != 1):
-        raise Exception("Trace is not 1d in snr.get_vpp. Abort")
-
-      # use provided time or create synthetic time if not given
-      if time is None:
-        time = np.arange(len(trace)) * dt
-      else:
-        if len(trace) != len(time):
-          raise ValueError("Provided time array must match trace length.")
+    elif isinstance(waveform, (list, tuple)):
+      if len(waveform) != 2:
+        raise ValueError("Waveform tuple or list must have length 2!")
+      time, trace = waveform
+      if (not isinstance(time, np.ndarray)) or (not isinstance(trace, np.ndarray)):
+        raise ValueError("Waveform must be tuple or list of np.ndarrays!")        
+      if len(trace) != len(time):
+        raise ValueError("Trace and time must have the same length.")
 
     else:
       raise Exception("Unsupported data type in snr.get_vpp. Abort")

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -44,12 +44,17 @@ def get_vpp(waveform, order = 1, use_local = True):
       vpp = trace.max() - trace.min()
       return vpp
 
+    # append 0 to the start and end of the trace to handle edge points in 'argrelextrema'
+    trace = np.pad(trace, (1, 1), mode = 'constant', constant_values = 0)
+
     # find local extrema
-    upper_peak_idx = argrelextrema(trace, np.greater_equal, order = order)[0]
-    lower_peak_idx = argrelextrema(trace, np.less_equal, order = order)[0]
+    upper_peak_idx = argrelextrema(trace, np.greater, order = order)[0]
+    lower_peak_idx = argrelextrema(trace, np.less, order = order)[0]
 
     # combine and sort indices (using np.unique)
     peak_idx = np.unique(np.concatenate((upper_peak_idx, lower_peak_idx)))
+    # adjust indices to account for the padding
+    peak_idx = peak_idx - 1
 
     # compute the difference between consecutive extrema and peak directly from indices 
     diff_peak = np.abs(np.diff(trace[peak_idx]))

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -48,11 +48,15 @@ def get_vpp(waveform, order = 1, use_local = True):
     padded_trace = np.pad(trace, (1, 1), mode = 'constant', constant_values = 0)
 
     # find local extrema
-    upper_peak_idx = argrelextrema(padded_trace, np.greater, order = order)[0]
-    lower_peak_idx = argrelextrema(padded_trace, np.less, order = order)[0]
+    upper_peak_idx = np.squeeze(argrelextrema(padded_trace, np.greater, order = order))
+    lower_peak_idx = np.squeeze(argrelextrema(padded_trace, np.less, order = order))
 
     # combine and sort indices (using np.unique)
     peak_idx = np.unique(np.concatenate((upper_peak_idx, lower_peak_idx)))
+
+    if len(peak_idx) == 0:
+      return 0.0
+
     # adjust indices to account for the padding
     peak_idx = peak_idx - 1
 

--- a/araproc/analysis/snr.py
+++ b/araproc/analysis/snr.py
@@ -1,6 +1,5 @@
 import ROOT
 import numpy as np
-from scipy.signal import argrelextrema
 
 from araproc.framework import waveform_utilities as wfu
 

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -881,7 +881,7 @@ class StandardReco:
            Channel pair correlation SNR.
         """
         
-        _, corr_func = wfu.tgraph_to_arrays(self.__get_correlation_function(ch1, ch2, wave_packet, False))
+        time, corr_func = wfu.tgraph_to_arrays(self.__get_correlation_function(ch1, ch2, wave_packet, False))
 
         # trim correlation function 
         corr_thresh = 1e-3
@@ -892,8 +892,12 @@ class StandardReco:
             return 0
         idxFirst = idxAboveThresh[0] # first above threshold
         idxLast = idxAboveThresh[-1] # last above threshold
-        corr_func = corr_func[idxFirst:idxLast+1] # trim to above threshold region
- 
+        corr_func = corr_func[idxFirst:idxLast+1] # trim correlation function to above threshold region
+        time = time[idxFirst:idxLast+1] # trim time to above threshold region
+
+        # convert the correlation function back to TGraph
+        corr_func = wfu.arrays_to_tgraph(time, corr_func)
+
         # calculate snr
         corr_snr = snr.get_snr(corr_func)
 


### PR DESCRIPTION
This PR makes changes in the `get_vpp` function for calculating peak-to-peak voltage. The changed function improves accuracy and flexibility by supporting both global and local extrema-based calculations. 

For a CP event
![CP](https://github.com/user-attachments/assets/4ce78cc3-ab46-4613-bc58-ac7b272e8902)

For a SPIce event
![SPIce](https://github.com/user-attachments/assets/8c7addf2-25d5-4531-bdb8-a505e1dfb149)

For an RF event (with signal)
![RF_Pulse](https://github.com/user-attachments/assets/b167ce32-5e7f-4d12-a1c5-8562f40bad9c)

For an RF event (with fluctuations)
![RF_Noise](https://github.com/user-attachments/assets/08581ba4-3047-4355-a618-19d64027d1be)
