### PR TITLE
Add CW ID frequency threshold and trace types for cw filtering- and bandpassing-only

### DIFF
--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -40,7 +40,7 @@ def apply_filters_one_channel(cw_filters, waveform_in):
     
     return latest_waveform
 
-def apply_filters(cw_filters, waveform_bundle, cw_ids = None):
+def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0.0):
 
     """
     Apply CW filters to a bundle of waveforms.
@@ -73,7 +73,7 @@ def apply_filters(cw_filters, waveform_bundle, cw_ids = None):
     check_cw_ids(cw_ids)
 
     filtered_waveforms = {}
-    active_cw_filters_v = get_active_filters(cw_filters, cw_ids, 0)
+    active_cw_filters_v = get_active_filters(cw_filters, cw_ids, 0, min_cw_id_freq)
     active_cw_filters_h = get_active_filters(cw_filters, cw_ids, 8)
     for ch_id, wave in waveform_bundle.items():
 
@@ -86,7 +86,7 @@ def apply_filters(cw_filters, waveform_bundle, cw_ids = None):
 
     return filtered_waveforms
 
-def get_active_filters(cw_filters, cw_ids, chan):
+def get_active_filters(cw_filters, cw_ids, chan, min_cw_id_freq):
     """
     Apply CW filters to a bundle of waveforms.
 
@@ -113,6 +113,15 @@ def get_active_filters(cw_filters, cw_ids, chan):
         return cw_filters
 
     active_filters = {}
+
+    # turn on all filters below the cw id freq threshold
+    for filter_i, filter in cw_filters.items():
+        fmax = filter["max_freq"]
+
+        # if filter covers region below cw id threshold, activate it 
+        if fmax < min_cw_id_freq:
+            active_filters[filter_i] = filter
+            
     
     if chan in const.vpol_channel_ids:
       pol = "v"

--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -74,7 +74,7 @@ def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0
 
     filtered_waveforms = {}
     active_cw_filters_v = get_active_filters(cw_filters, cw_ids, 0, min_cw_id_freq)
-    active_cw_filters_h = get_active_filters(cw_filters, cw_ids, 8)
+    active_cw_filters_h = get_active_filters(cw_filters, cw_ids, 8, min_cw_id_freq)
     for ch_id, wave in waveform_bundle.items():
 
         if ch_id in const.vpol_channel_ids:

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -763,6 +763,8 @@ class AnalysisDataset:
         Most users will leave this False.
     path_to_cw_ids : str
         the full path to the file containing identified CW frequencies for this data file
+    min_cw_id_freq : float
+        minimum frequency for CW ID (in GHz), all filters below this frequency are always activated
     run_number: int
         ARA run number for this dataset
         This will be inferred from the data itself
@@ -802,11 +804,13 @@ class AnalysisDataset:
                  is_simulation : bool = False,
                  do_not_calibrate : bool = False,
                  path_to_cw_ids : str = None,
+                 min_cw_id_freq : float = 0.120,
                  ):
     
         self.is_simulation = is_simulation
         self.do_not_calibrate = do_not_calibrate
         self.path_to_cw_ids = path_to_cw_ids
+        self.min_cw_id_freq = min_cw_id_freq
 
         if self.is_simulation and self.do_not_calibrate:
             raise Exception(f"Simulation (is_simulation = {self.is_simulation}) and uncalibrated data (do_not_calibrate = {self.do_not_calibrate}) are incompatible settings")
@@ -845,7 +849,8 @@ class AnalysisDataset:
                                                  path_to_pedestal_file,
                                                  station_id=station_id,
                                                  do_not_calibrate = self.do_not_calibrate,
-                                                 path_to_cw_ids = self.path_to_cw_ids
+                                                 path_to_cw_ids = self.path_to_cw_ids,
+                                                 min_cw_id_freq = self.min_cw_id_freq,
                                              )
         else:
             self.dataset_wrapper = SimWrapper(path_to_data_file,


### PR DESCRIPTION
This PR adds a minimum CW ID frequency above which CW ID will be used to turn on filters. Below this frequency, all filters are turned on. (Ideally this would be removed someday.) The default is 120 MHz, which is what we used in our phase variance processing, but it can be adjusted by passing an argument when making the dataset object.

Also added two trace types: `cw_filtered` and `bandpassed` which only apply their respective filter. 