### PR TITLE
Make A2 CW filters full band with no overlap 

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -41,13 +41,13 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
@@ -56,13 +56,13 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
@@ -71,13 +71,13 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
@@ -86,13 +86,13 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
@@ -101,13 +101,13 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
@@ -116,15 +116,15 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.230, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.230, max_freq : 0.270, min_power_ratio : 0.02 } # Targeting 250 MHz
-      filt1 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt5 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt7 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt9 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt10 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt11 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 12
@@ -133,15 +133,15 @@ station2:
     filters:
       filt1 : { min_freq : 0.000, max_freq : 0.230, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.230, max_freq : 0.270, min_power_ratio : 0.02 } # Targeting 250 MHz
-      filt1 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt5 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt7 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt9 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt10 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt11 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 12

--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -39,74 +39,109 @@ station2:
   config1:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config2:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config3:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config4:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
   config5:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.400, max_freq : 0.500, min_power_ratio : 0.10 }
-      filt5 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.456, max_freq : 0.458, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
   config6:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.149, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.230, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.230, max_freq : 0.270, min_power_ratio : 0.02 } # Targeting 250 MHz
+      filt1 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 12
   config7:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.124, max_freq : 0.126, min_power_ratio : 0.02 }
-      filt2 : { min_freq : 0.145, max_freq : 0.151, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
+      filt1 : { min_freq : 0.000, max_freq : 0.230, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.230, max_freq : 0.270, min_power_ratio : 0.02 } # Targeting 250 MHz
+      filt1 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
+      filt1 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
+      filt1 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
+      filt1 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
+      filt1 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 12

--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -39,109 +39,112 @@ station2:
   config1:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config2:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config3:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 20
       soft_readout_limit: 8
   config4:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
   config5:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt3 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt5 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt7 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt9 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 26
       soft_readout_limit: 8
   config6:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.230, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.230, max_freq : 0.270, min_power_ratio : 0.02 } # Targeting 250 MHz
-      filt3 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt5 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt7 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt9 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt10 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt11 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 12
   config7:
     excluded_channels : [15] # always exclude channel 15
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.230, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.230, max_freq : 0.270, min_power_ratio : 0.02 } # Targeting 250 MHz
-      filt3 : { min_freq : 0.270, max_freq : 0.280, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.02 } # Targeting 300 MHz
-      filt5 : { min_freq : 0.320, max_freq : 0.360, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.360, max_freq : 0.420, min_power_ratio : 0.02 } # Targeting 380 MHz and 407 MHz
-      filt7 : { min_freq : 0.420, max_freq : 0.450, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.450, max_freq : 0.520, min_power_ratio : 0.02 } # Targeting 470 MHz and 500 MHz
-      filt9 : { min_freq : 0.520, max_freq : 0.930, min_power_ratio : 0.10 }
-      filt10 : { min_freq : 0.930, max_freq : 0.970, min_power_ratio : 0.02 } # Targeting 950 MHz
-      filt11 : { min_freq : 0.970, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.120, max_freq : 0.138, min_power_ratio : 0.10 }
+      filt3 : { min_freq : 0.138, max_freq : 0.149, min_power_ratio : 0.02 } # Targetting 142 and 146 MHz
+      filt4 : { min_freq : 0.149, max_freq : 0.248, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.248, max_freq : 0.254, min_power_ratio : 0.005 } # Targeting 251 MHz
+      filt6 : { min_freq : 0.254, max_freq : 0.376, min_power_ratio : 0.10 }
+      filt7 : { min_freq : 0.376, max_freq : 0.382, min_power_ratio : 0.02 } # Targeting 379 MHz
+      filt8 : { min_freq : 0.382, max_freq : 0.400, min_power_ratio : 0.10 } 
+      filt9 : { min_freq : 0.400, max_freq : 0.408, min_power_ratio : 0.02 } # Targeting 404 MHz
+      filt10 : { min_freq : 0.408, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 12


### PR DESCRIPTION
Targeting 250, 300, 380, 407, 470, 500, and 950 MHz with the 2% power CW filter by looking in a window roughly +/- 20 MHz around each frequency. The rest of the frequency space is monitored with the 10% CW filter 