### PR TITLE
Ensure CW filters are always sorted

### DIFF
--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -109,8 +109,9 @@ def get_active_filters(cw_filters, cw_ids, chan, min_cw_id_freq):
         A dictionary of sine subtract filters to be applied for this event and channel.
     """
 
-    if cw_ids is None:
-        return cw_filters
+    if cw_ids is None: # if cw id isn't present activate all filters
+        active_filters = sort_filters(cw_filters)
+        return active_filters
 
     active_filters = {}
 
@@ -152,10 +153,7 @@ def get_active_filters(cw_filters, cw_ids, chan, min_cw_id_freq):
             unFilteredFreqs = badFreqs[~isFiltered]
             raise Exception(f"IDed CW at {unFilteredFreqs} GHz has no corresponding filter! Please add one and rerun.")
 
-    # filters are applied in order they appear in dict
-    # there's some advantage to apply them in order of descending 
-    # min_power_ratio, so let's quickly enforce that
-    active_filters = {k : v for k, v in sorted(active_filters.items(), key=lambda x: x[1]["min_power_ratio"], reverse=True)}
+    active_filters = sort_filters(active_filters)
 
     return active_filters
 
@@ -182,4 +180,26 @@ def check_cw_ids(cw_ids):
         if np.any(badFreqs > 2.):
             raise ValueError("Frequency >2 detected in CW IDs. Please ensure units are GHz. Abort.")
 
+    return
+
+def sort_filters(filters):
+    """
+    Helper function to sort filters in order of descending
+    min_power_ratio, which appears to have some advantage 
+    (filters are applied in order they are inserted into dict)
+
+    Parameters
+    ----------
+    filters : dict
+        Dictionary of filters to sort
+
+    Returns
+    -------
+    sorted_filters : dict
+        Dictionary of sorted filters
+    """
+
+    sorted_filters = {k : v for k, v in sorted(filters.items(), key=lambda x: x[1]["min_power_ratio"], reverse=True)}
+
+    return sorted_filters
 

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -457,12 +457,26 @@ class DataWrapper:
         ROOT.SetOwnership(useful_event, True)
         
         # if we have cw ids loaded, get the corresponding entry to this event 
-        if self.cw_id_tree is not None:
-            event_number = useful_event.eventNumber
-            if self.cw_id_tree.GetEntryWithIndex(event_number) < 0:
-                raise Exception(f"Unable to get corresponding cw id entry for {event_number}.")
+        event_number = useful_event.eventNumber
+        self.get_cw_id_entry(event_number)
  
         return useful_event
+
+    def get_cw_id_entry(self, event_number):
+        """
+        Get the CW ID tree entry for an event.
+
+        Parameters
+        ----------
+        event_number : int
+          Event number to load CW ID for.
+        """
+
+        if self.cw_id_tree is not None:
+            if self.cw_id_tree.GetEntryWithIndex(event_number) < 0:
+                raise Exception(f"Unable to get corresponding cw id entry for {event_number}.")
+        
+        return 
 
     def get_cw_ids(self):
         """
@@ -475,6 +489,46 @@ class DataWrapper:
         """
 
         return self.cw_id_ptrs
+        
+    def get_event_cw(self, useful_event):
+        """
+        Get the IDed CW frequencies in each polarization for the loaded event.
+
+        Parameters
+        ----------
+        useful_event : UsefulAtriStationEvent
+            The pointer to the UsefulAtriStationEvent
+
+        Returns
+        -------
+        cw_v, cw_h : numpy arrays
+            Arrays of the IDed frequencies in both scan directions for each polarization.
+
+        """
+        
+        # if we have cw ids loaded, get the corresponding entry to this event 
+        event_number = useful_event.eventNumber
+        self.get_cw_id_entry(event_number)
+  
+        cw = {"v" : [],
+              "h" : []}
+        cw_ids = self.get_cw_ids()
+        if cw_ids is None:
+             raise Exception("No event loaded, so I can't tell you what the CW frequencies are!")
+
+        scan_directions = ["fwd", "bwd"]
+        for direction in scan_directions:
+            for pol in cw.keys():
+                key = f"badFreqs_{direction}_{pol}"
+                badFreqs = np.asarray(cw_ids[key])
+        
+                cw[pol].extend(badFreqs)
+
+        cw["v"] = np.unique(np.asarray(cw["v"]))
+        cw["h"] = np.unique(np.asarray(cw["h"]))
+
+        return cw["v"], cw["h"]
+ 
 
     def get_event_index(self, event_number):
         """
@@ -942,7 +996,14 @@ class AnalysisDataset:
             return None 
 
         return self.dataset_wrapper.get_cw_ids()
- 
+
+    def get_event_cw(self, useful_event): 
+
+        if self.is_simulation:
+            return [], []
+
+        return self.dataset_wrapper.get_event_cw(useful_event)
+       
     def get_event_index(self, 
                             event_number : int = None):
 
@@ -1091,7 +1152,12 @@ class AnalysisDataset:
             return wavepacket
     
         # and if they want filtered waves
+        event_number = useful_event.eventNumber
+        if not self.is_simulation: # if this is real data, ensure the right cw IDs are loaded
+            self.dataset_wrapper.get_cw_id_entry(event_number)
+
         if which_traces != "bandpassed": # if we're not only bandpassing, apply CW filters
+            
             cw_ids = self.get_cw_ids()
             filtered_waves = cwf.apply_filters(self.__cw_filters, dedispersed_waves, cw_ids, self.min_cw_id_freq)
             

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -510,12 +510,15 @@ class DataWrapper:
         event_number = useful_event.eventNumber
         self.get_cw_id_entry(event_number)
   
-        cw = {"v" : [],
-              "h" : []}
         cw_ids = self.get_cw_ids()
         if cw_ids is None:
-             raise Exception("No event loaded, so I can't tell you what the CW frequencies are!")
+             raise Exception("No event loaded, so CW frequencies can't be determined!")
 
+        # collect frequencies in each polarization (v & h) identified 
+        # when calculating phase variance with events
+        # behind (bwd) and ahead (fwd) of this one
+        cw = {"v" : [],
+              "h" : []}
         scan_directions = ["fwd", "bwd"]
         for direction in scan_directions:
             for pol in cw.keys():


### PR DESCRIPTION
This PR ensures CW filters are always applied in order of descending `min_power_ratio`. This was already enforced when CW ID is being used and previously was enforced by users via the ordering in yaml files when CW ID wasn't used. This update ensures the order that CW filters are applied is uniform.

Also added a getter function to have easier access to the flagged CW frequencies in each polarization of an event.