### PR TITLE
Fixed expected readout lengths for A3 config 1

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -181,8 +181,8 @@ station3:
       filt3 : { min_freq : 0.249, max_freq : 0.251, min_power_ratio : 0.02 }
       filt4 : { min_freq : 0.400, max_freq : 0.406, min_power_ratio : 0.02 }
     readout_limits:
-      rf_readout_limit: 45
-      soft_readout_limit: 12
+      rf_readout_limit: 20
+      soft_readout_limit: 8
   config2:
     excluded_channels : []
     filters:


### PR DESCRIPTION
Adjusted the expected readout lengths for A3 config 1 to the right values from data. These were set incorrectly due to this number being missing from most of the DAQ config logs that the scraping script pulls data from. The result was that essentially every event in the config was flagged as bad quality, even though there is nothing outwardly wrong with it. This fixes that error.