### PR TITLE
Added and adjusted filters for A5.

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -459,9 +459,9 @@ station5:
       filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
       filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
       filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }
-      filt9 : { min_freq : 0.505, max_freq : 0.745, min_power_ratio : 0.10 }
-      filt10 : { min_freq : 0.745, max_freq : 0.760, min_power_ratio : 0.01 }
-      filt11 : { min_freq : 0.760, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt9 : { min_freq : 0.505, max_freq : 0.750, min_power_ratio : 0.10 }
+      filt10 : { min_freq : 0.750, max_freq : 0.756, min_power_ratio : 0.0005 }
+      filt11 : { min_freq : 0.756, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 10
@@ -476,9 +476,9 @@ station5:
       filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
       filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
       filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }
-      filt9 : { min_freq : 0.505, max_freq : 0.745, min_power_ratio : 0.10 }
-      filt10 : { min_freq : 0.745, max_freq : 0.760, min_power_ratio : 0.01 }
-      filt11 : { min_freq : 0.760, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt9 : { min_freq : 0.505, max_freq : 0.750, min_power_ratio : 0.10 }
+      filt10 : { min_freq : 0.750, max_freq : 0.756, min_power_ratio : 0.0005 }
+      filt11 : { min_freq : 0.756, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 10

--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -455,7 +455,7 @@ station5:
       filt2 : { min_freq : 0.045, max_freq : 0.065, min_power_ratio : 0.01 }
       filt3 : { min_freq : 0.065, max_freq : 0.120, min_power_ratio : 0.10 }
       filt4 : { min_freq : 0.120, max_freq : 0.130, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.130, max_freq : 0.245, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.130, max_freq : 0.240, min_power_ratio : 0.10 }
       filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
       filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
       filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }
@@ -472,7 +472,7 @@ station5:
       filt2 : { min_freq : 0.045, max_freq : 0.065, min_power_ratio : 0.01 }
       filt3 : { min_freq : 0.065, max_freq : 0.120, min_power_ratio : 0.10 }
       filt4 : { min_freq : 0.120, max_freq : 0.130, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.130, max_freq : 0.245, min_power_ratio : 0.10 }
+      filt5 : { min_freq : 0.130, max_freq : 0.240, min_power_ratio : 0.10 }
       filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
       filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
       filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }

--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -451,26 +451,34 @@ station5:
   config1:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.120, max_freq : 0.140, min_power_ratio : 0.05 }
-      filt3 : { min_freq : 0.140, max_freq : 0.320, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.320, max_freq : 0.340, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.340, max_freq : 0.495, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.510, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.045, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.045, max_freq : 0.065, min_power_ratio : 0.01 }
+      filt3 : { min_freq : 0.065, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.120, max_freq : 0.130, min_power_ratio : 0.02 }
+      filt5 : { min_freq : 0.130, max_freq : 0.245, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
+      filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }
+      filt9 : { min_freq : 0.505, max_freq : 0.745, min_power_ratio : 0.10 }
+      filt10 : { min_freq : 0.745, max_freq : 0.760, min_power_ratio : 0.01 }
+      filt11 : { min_freq : 0.760, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 10
   config2:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.120, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.120, max_freq : 0.140, min_power_ratio : 0.05 }
-      filt3 : { min_freq : 0.140, max_freq : 0.320, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.320, max_freq : 0.340, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.340, max_freq : 0.495, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.510, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.045, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.045, max_freq : 0.065, min_power_ratio : 0.01 }
+      filt3 : { min_freq : 0.065, max_freq : 0.120, min_power_ratio : 0.10 }
+      filt4 : { min_freq : 0.120, max_freq : 0.130, min_power_ratio : 0.02 }
+      filt5 : { min_freq : 0.130, max_freq : 0.245, min_power_ratio : 0.10 }
+      filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
+      filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
+      filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }
+      filt9 : { min_freq : 0.505, max_freq : 0.745, min_power_ratio : 0.10 }
+      filt10 : { min_freq : 0.745, max_freq : 0.760, min_power_ratio : 0.01 }
+      filt11 : { min_freq : 0.760, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 10


### PR DESCRIPTION
This adds filters identified by dataset.get_cw_ids. There is also a filter added at 55 MHz, but it is kept weak enough that it does not eliminate the peaks there. Some example spectra are added here.
[A5_C1_2515_94198_unfiltered.pdf](https://github.com/user-attachments/files/20094446/A5_C1_2515_94198_unfiltered.pdf)
[A5_C1_2515_94198_filtered.pdf](https://github.com/user-attachments/files/20094447/A5_C1_2515_94198_filtered.pdf)
[A5_C1_2484_31093_unfiltered.pdf](https://github.com/user-attachments/files/20094451/A5_C1_2484_31093_unfiltered.pdf)
[A5_C1_2484_31093_filtered.pdf](https://github.com/user-attachments/files/20094452/A5_C1_2484_31093_filtered.pdf)
