### PR TITLE
Add functionality for max CW ID frequency

### DIFF
--- a/araproc/analysis/cw_filter.py
+++ b/araproc/analysis/cw_filter.py
@@ -44,7 +44,7 @@ def apply_filters_one_channel(cw_filters, active_cw_filters, waveform_in):
     
     return latest_waveform
 
-def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0.0):
+def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0.0, max_cw_id_freq = 1.0):
 
     """
     Apply CW filters to a bundle of waveforms.
@@ -64,6 +64,10 @@ def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0
         A tuple of numpy arrays containing cw id info.
         If None, all set CW filters allowed to filter. Otherwise, only those 
         covering frequencies in the cw id info will be allowed to filter.
+    min_cw_id_freq : float
+        minimum frequency for CW ID (in GHz), all filters below this frequency are always activated
+    max_cw_id_freq : float
+        maximum frequency for CW ID (in GHz), all filters above this frequency are always activated
 
     Returns
     -------
@@ -77,8 +81,8 @@ def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0
     check_cw_ids(cw_ids)
 
     filtered_waveforms = {}
-    active_cw_filters_v = get_active_filters(cw_filters, cw_ids, 0, min_cw_id_freq)
-    active_cw_filters_h = get_active_filters(cw_filters, cw_ids, 8, min_cw_id_freq)
+    active_cw_filters_v = get_active_filters(cw_filters, cw_ids, 0, min_cw_id_freq, max_cw_id_freq)
+    active_cw_filters_h = get_active_filters(cw_filters, cw_ids, 8, min_cw_id_freq, max_cw_id_freq)
     for ch_id, wave in waveform_bundle.items():
 
         if ch_id in const.vpol_channel_ids:
@@ -90,7 +94,7 @@ def apply_filters(cw_filters, waveform_bundle, cw_ids = None, min_cw_id_freq = 0
 
     return filtered_waveforms
 
-def get_active_filters(cw_filters, cw_ids, chan, min_cw_id_freq):
+def get_active_filters(cw_filters, cw_ids, chan, min_cw_id_freq, max_cw_id_freq):
     """
     Apply CW filters to a bundle of waveforms.
 
@@ -123,10 +127,11 @@ def get_active_filters(cw_filters, cw_ids, chan, min_cw_id_freq):
     
     # turn on all filters below the cw id freq threshold
     for filter_i, filter in cw_filters.items():
+        fmin = filter["min_freq"]
         fmax = filter["max_freq"]
 
-        # if filter covers region below cw id threshold, activate it 
-        if fmax < min_cw_id_freq:
+        # if filter covers region outside cw id band, activate it 
+        if fmax < min_cw_id_freq or fmin > max_cw_id_freq:
             active_filters[filter_i] = True
             
     # grab the relevant bad frequencies for this polarization

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -101,6 +101,8 @@ class DataWrapper:
         the ROOT TTreeReader of the cw id tree
     min_cw_id_freq : float
         minimum frequency for CW ID (in GHz), all filters below this frequency are always activated
+    max_cw_id_freq : float
+        maximum frequency for CW ID (in GHz), all filters above this frequency are always activated
     run_number: int
         ARA run number for this dataset
         This will be inferred from the data itself
@@ -134,13 +136,15 @@ class DataWrapper:
                  do_not_calibrate : bool = False,
                  path_to_cw_ids : str = None,
                  min_cw_id_freq : float = 0.120,
+                 max_cw_id_freq : float = 0.500,
                  ):
         
         self.path_to_data_file = None
         self.path_to_pedestal_file = None
         self.do_not_calibrate = do_not_calibrate
         self.path_to_cw_ids = None
-        self.min_cw_id_freq = 0.120
+        self.min_cw_id_freq = min_cw_id_freq
+        self.max_cw_id_freq = max_cw_id_freq
         self.root_tfile = None
         self.event_tree = None
         self.cw_id_tfile = None
@@ -949,6 +953,8 @@ class AnalysisDataset:
         the full path to the file containing identified CW frequencies for this data file
     min_cw_id_freq : float
         minimum frequency for CW ID (in GHz), all filters below this frequency are always activated
+    max_cw_id_freq : float
+        maximum frequency for CW ID (in GHz), all filters above this frequency are always activated
     run_number: int
         ARA run number for this dataset
         This will be inferred from the data itself
@@ -989,12 +995,14 @@ class AnalysisDataset:
                  do_not_calibrate : bool = False,
                  path_to_cw_ids : str = None,
                  min_cw_id_freq : float = 0.120,
+                 max_cw_id_freq : float = 0.500,
                  ):
     
         self.is_simulation = is_simulation
         self.do_not_calibrate = do_not_calibrate
         self.path_to_cw_ids = path_to_cw_ids
         self.min_cw_id_freq = min_cw_id_freq
+        self.max_cw_id_freq = max_cw_id_freq
 
         if self.is_simulation and self.do_not_calibrate:
             raise Exception(f"Simulation (is_simulation = {self.is_simulation}) and uncalibrated data (do_not_calibrate = {self.do_not_calibrate}) are incompatible settings")
@@ -1035,6 +1043,7 @@ class AnalysisDataset:
                                                  do_not_calibrate = self.do_not_calibrate,
                                                  path_to_cw_ids = self.path_to_cw_ids,
                                                  min_cw_id_freq = self.min_cw_id_freq,
+                                                 max_cw_id_freq = self.max_cw_id_freq,
                                              )
         else:
             self.dataset_wrapper = SimWrapper(path_to_data_file,
@@ -1287,7 +1296,7 @@ class AnalysisDataset:
             
             event_number = useful_event.eventNumber
             cw_ids = self.get_cw_ids(event_number)
-            filtered_waves = cwf.apply_filters(self.__cw_filters, filtered_waves, cw_ids, self.min_cw_id_freq)
+            filtered_waves = cwf.apply_filters(self.__cw_filters, filtered_waves, cw_ids, self.min_cw_id_freq, self.max_cw_id_freq)
  
 
         # and finally, apply some bandpass cleanup filters


### PR DESCRIPTION
Adds a `max_cw_id_freq` parameter which controls the maximum frequency up to which CW ID is used to activate filters. CW filters from `min_cw_id_freq` to `max_cw_id_freq` are only activated if they cover a frequency IDed in the CW ID file. Filters outside this band are always turned on.