### PR TITLE
new_A5_CW_filter_C2_year2019

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -484,17 +484,20 @@ station5:
   config2:
     excluded_channels : []
     filters:
-      filt1 : { min_freq : 0.000, max_freq : 0.045, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.045, max_freq : 0.065, min_power_ratio : 0.01 }
-      filt3 : { min_freq : 0.065, max_freq : 0.120, min_power_ratio : 0.10 }
-      filt4 : { min_freq : 0.120, max_freq : 0.130, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.130, max_freq : 0.240, min_power_ratio : 0.10 }
-      filt6 : { min_freq : 0.240, max_freq : 0.260, min_power_ratio : 0.002 }
-      filt7 : { min_freq : 0.260, max_freq : 0.495, min_power_ratio : 0.10 }
-      filt8 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.002 }
-      filt9 : { min_freq : 0.505, max_freq : 0.750, min_power_ratio : 0.10 }
-      filt10 : { min_freq : 0.750, max_freq : 0.756, min_power_ratio : 0.0005 }
-      filt11 : { min_freq : 0.756, max_freq : 1.000, min_power_ratio : 0.10 }
+      filt1 : { min_freq : 0.000, max_freq : 0.122, min_power_ratio : 0.10 }
+      filt2 : { min_freq : 0.122, max_freq : 0.127, min_power_ratio : 0.0006 }
+      filt3 : { min_freq : 0.127, max_freq : 0.130, min_power_ratio : 0.001 }
+      filt4 : { min_freq : 0.130, max_freq : 0.160, min_power_ratio : 0.002 }
+      filt5 : { min_freq : 0.160, max_freq : 0.200, min_power_ratio : 0.10}  
+      filt6 : { min_freq : 0.200, max_freq : 0.260, min_power_ratio : 0.003 }
+      filt7 : { min_freq : 0.260, max_freq : 0.280, min_power_ratio : 0.06 }
+      filt8 : { min_freq : 0.280, max_freq : 0.320, min_power_ratio : 0.1 }
+      filt9 : { min_freq : 0.320, max_freq : 0.340, min_power_ratio : 0.02 }
+      filt10 : { min_freq : 0.340, max_freq : 0.380, min_power_ratio : 0.10 }
+      filt11 : { min_freq : 0.380, max_freq : 0.420, min_power_ratio : 0.001 }
+      filt12 : { min_freq : 0.420, max_freq : 0.495, min_power_ratio : 0.1 }
+      filt13 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.02 }
+      filt14 : { min_freq : 0.510, max_freq : 1.000, min_power_ratio : 0.10 }
     readout_limits:
       rf_readout_limit: 28
       soft_readout_limit: 10


### PR DESCRIPTION
This update includes a refined CW filter for A5 Config 2 (only 2019), specifically targeting high corr-low avg_SNR_v events. For all such events, CW peaks were carefully examined and the filter parameters were adjusted  PV identification and also checked by eye. 
In each case tested so far, applying the updated filter successfully removes the CW peaks (except 1 outlier that has been discussed on slack on 14th May). 
