### PR TITLE
update the dedisperser with padding

### DIFF
--- a/araproc/analysis/dedisperse.py
+++ b/araproc/analysis/dedisperse.py
@@ -54,7 +54,7 @@ def dedisperse_wave(
         volts, # in volts,
         phase_spline, # the phase spline
         pre_pad_ns=40.0,  # amount of zero prepadding before dedispersion (ns)
-        final_crop_ns=10.0  # amount of padding to keep after dedispersion (ns)
+        final_crop_ns=10.0  # amount of prepadding to keep after dedispersion (ns)
         ):
     
     """

--- a/araproc/analysis/dedisperse.py
+++ b/araproc/analysis/dedisperse.py
@@ -53,7 +53,7 @@ def dedisperse_wave(
         times, # in nanoseconds,
         volts, # in volts,
         phase_spline, # the phase spline
-        pre_pad_ns=40.0,  # amount of zero padding before dedispersion (ns)
+        pre_pad_ns=40.0,  # amount of zero prepadding before dedispersion (ns)
         final_crop_ns=10.0  # amount of padding to keep after dedispersion (ns)
         ):
     
@@ -97,7 +97,7 @@ def dedisperse_wave(
     dt = times[1] - times[0]  # assuming uniform sampling
     
     # Calculate number of padding samples needed
-    n_pad_samples = int(pre_pad_ns / dt)
+    n_pad_samples = int(np.round(pre_pad_ns / dt))
     
     # Create padded time array: from (t_i - pre_pad_ns) to t_f
     t_start_padded = times[0] - pre_pad_ns
@@ -105,7 +105,7 @@ def dedisperse_wave(
     
     # Create padded voltage array with zeros at the beginning
     padded_volts = np.zeros(len(padded_times))
-    padded_volts[n_pad_samples:n_pad_samples+len(volts)] = volts
+    padded_volts[n_pad_samples:] = volts
     
     # Get the frequency domain representation of the padded trace
     freqs, spectrum = wu.time2freq(padded_times, padded_volts)
@@ -123,10 +123,10 @@ def dedisperse_wave(
     dedispersed_times, dedispersed_volts = wu.freq2time(padded_times, spectrum)
     
     # Crop the result: keep from (t_i - final_crop_ns) to t_f
-    t_start_final = times[0] - final_crop_ns
+    t_start_after_pad_and_crop = times[0] - final_crop_ns
     
     # Find the indices for cropping
-    crop_start_idx = np.argmin(np.abs(dedispersed_times - t_start_final))
+    crop_start_idx = np.argmin(np.abs(dedispersed_times - t_start_after_pad_and_crop))
     original_end_idx = np.argmin(np.abs(dedispersed_times - times[-1]))
     
     # Crop to final desired range

--- a/araproc/analysis/dedisperse.py
+++ b/araproc/analysis/dedisperse.py
@@ -52,11 +52,13 @@ def eval_splined_phases(phase_spline, freqs_to_evaluate):
 def dedisperse_wave(
         times, # in nanoseconds,
         volts, # in volts,
-        phase_spline # the  phase spline
+        phase_spline, # the phase spline
+        pre_pad_ns=40.0,  # amount of zero padding before dedispersion (ns)
+        final_crop_ns=10.0  # amount of padding to keep after dedispersion (ns)
         ):
     
     """
-    Fetch a specific calibrated event
+    Fetch a specific calibrated event with configurable padding
 
     Parameters
     ----------
@@ -71,9 +73,18 @@ def dedisperse_wave(
         When the function was first written, it was meant to utilize
         the output of `dedisperse.load_arasim_phase_response_as_spline`.
         So check that function for an example of how to do it.
+    pre_pad_ns : float, optional
+        Amount of zero padding to add before dedispersion, in ns
+    final_crop_ns : float, optional
+        Amount of the pre-padding to keep in final result, in ns.
+        The default value of 10 ns is selected by looking at the 
+        "average" group delay (by eye) within the band.
+        
 
     Returns
     -------
+    times : np.ndarray(dtype=np.float64)
+        The time array for the dedispersed wave
     dedispersed_wave : np.ndarray(dtype=np.float64)
         The dedispersed wave
         
@@ -82,20 +93,44 @@ def dedisperse_wave(
     if len(times) != len(volts):
         raise Exception("The time and volts arrays are mismatched in length. Abort.")
 
-    # first thing to do is get the frequency domain representation of the trace
-
-
-    freqs, spectrum = wu.time2freq(times, volts)
+    # Calculate time step from the input times array
+    dt = times[1] - times[0]  # assuming uniform sampling
+    
+    # Calculate number of padding samples needed
+    n_pad_samples = int(pre_pad_ns / dt)
+    
+    # Create padded time array: from (t_i - pre_pad_ns) to t_f
+    t_start_padded = times[0] - pre_pad_ns
+    padded_times = np.arange(t_start_padded, times[-1] + dt/2, dt)
+    
+    # Create padded voltage array with zeros at the beginning
+    padded_volts = np.zeros(len(padded_times))
+    padded_volts[n_pad_samples:n_pad_samples+len(volts)] = volts
+    
+    # Get the frequency domain representation of the padded trace
+    freqs, spectrum = wu.time2freq(padded_times, padded_volts)
 
     # interpolate the *unwrapped phases* to the correct frequency base
     phased_interpolated = eval_splined_phases(phase_spline, freqs)
     
-    # conver these into a complex number
+    # convert these into a complex number
     phased_rewrapped = np.exp((0 + 1j)*phased_interpolated)
     
     # do complex division to do the dedispersion
     spectrum /= phased_rewrapped
 
     # back to the time domain
-    times, volts = wu.freq2time(times, spectrum)
-    return times, volts
+    dedispersed_times, dedispersed_volts = wu.freq2time(padded_times, spectrum)
+    
+    # Crop the result: keep from (t_i - final_crop_ns) to t_f
+    t_start_final = times[0] - final_crop_ns
+    
+    # Find the indices for cropping
+    crop_start_idx = np.argmin(np.abs(dedispersed_times - t_start_final))
+    original_end_idx = np.argmin(np.abs(dedispersed_times - times[-1]))
+    
+    # Crop to final desired range
+    crop_times = dedispersed_times[crop_start_idx:original_end_idx+1]
+    crop_volts = dedispersed_volts[crop_start_idx:original_end_idx+1]
+    
+    return crop_times, crop_volts

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -131,6 +131,8 @@ def plot_waveform_bundle(
             ax2.set_ylabel("lg(Fractional Power)")
       else:
           axd[ch].set_ylim(ymin, ymax)
+          axd[ch].set_ylim(-1000, 1000)
+          axd[ch].set_xlim(-200,200)
 
     # save figure
     fig.savefig(output_file_path)

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -131,8 +131,6 @@ def plot_waveform_bundle(
             ax2.set_ylabel("lg(Fractional Power)")
       else:
           axd[ch].set_ylim(ymin, ymax)
-          axd[ch].set_ylim(-1000, 1000)
-          axd[ch].set_xlim(-200,200)
 
     # save figure
     fig.savefig(output_file_path)


### PR DESCRIPTION
This updates the dedisperser module. The idea here is that we want to pad the waveform with some buffer (in this case, 40 ns) before the dedispersion. This is necessary because the group delay of the system pushes the signal forward, so when it is removed, the signal shifts backwards in time. If we don't have any pre-padding, then the signal wraps around to the end of the trace, which is explicitly incorrect. We don't want to keep all of the pre-pad tho. So in this case, we pre-pad by 40 ns, and then keep 10 ns. The 10 ns is chosen by studying the largest group delay we see in the system response where the bandpass is still substantial. See the following plot.

![channel_0_gaussian_pulse](https://github.com/user-attachments/assets/eed79a9d-f81a-4131-9081-34d5bc9bda63)
