### PR TITLE
New masking decisions on A3, compatible with MKs

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -149,7 +149,7 @@ station3:
       filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.02 }
       filt7 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.02 }
   config6:
-    excluded_channels : [3, 7, 11, 15]
+    excluded_channels : [0, 4, 8, 12, 3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
@@ -158,7 +158,7 @@ station3:
       filt5 : { min_freq : 0.400, max_freq : 0.410, min_power_ratio : 0.002 }
       filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.002 }
   config7:
-    excluded_channels : [3, 7, 11, 15]
+    excluded_channels : [3]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
@@ -168,7 +168,7 @@ station3:
       filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.005 }
       filt7 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.01 }
   config8:
-    excluded_channels : [3, 7, 11, 15]
+    excluded_channels : [3]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
@@ -177,7 +177,7 @@ station3:
       filt5 : { min_freq : 0.400, max_freq : 0.510, min_power_ratio : 0.01 }
       filt6 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.01 }
   config9:
-    excluded_channels : [0, 4, 8, 12]
+    excluded_channels : [3]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.210, min_power_ratio : 0.02 }


### PR DESCRIPTION
A full explanation for each masking decision is in: https://aradocs.wipac.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=3408

In summary, out analysis antenna masks were out of sync with Myougchul's findings.