### PR TITLE
New filters to fix CP reco

### DIFF
--- a/araproc/framework/config_files/analysis_configs.yaml
+++ b/araproc/framework/config_files/analysis_configs.yaml
@@ -126,69 +126,65 @@ station3:
     excluded_channels : [3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.120, max_freq : 0.195, min_power_ratio : 0.02 }
+      filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
       filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.01 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
       filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
-      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.005 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
   config4:
     excluded_channels : [3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.120, max_freq : 0.128, min_power_ratio : 0.001 }
-      filt3 : { min_freq : 0.140, max_freq : 0.330, min_power_ratio : 0.01 }
-      filt4 : { min_freq : 0.370, max_freq : 0.408, min_power_ratio : 0.01 }
-      filt5 : { min_freq : 0.430, max_freq : 0.510, min_power_ratio : 0.01 }
-      filt6 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.01 } 
+      filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
+      filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
+      filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
   config5:
     excluded_channels : [3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.235, max_freq : 0.255, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.290, max_freq : 0.330, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.400, max_freq : 0.470, min_power_ratio : 0.01 }
-      filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.02 }
-      filt7 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.02 }
+      filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
+      filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
   config6:
     excluded_channels : [0, 4, 8, 12, 3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.240, max_freq : 0.255, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.295, max_freq : 0.330, min_power_ratio : 0.002 }
-      filt5 : { min_freq : 0.400, max_freq : 0.410, min_power_ratio : 0.002 }
-      filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.002 }
+      filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
+      filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
   config7:
     excluded_channels : [0, 4, 8, 12, 3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.240, max_freq : 0.255, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.295, max_freq : 0.330, min_power_ratio : 0.005 }
-      filt5 : { min_freq : 0.400, max_freq : 0.430, min_power_ratio : 0.007 }
-      filt6 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.005 }
-      filt7 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.01 }
+      filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
+      filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
   config8:
     excluded_channels : [0, 4, 8, 12, 3, 7, 11, 15]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
       filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.190, max_freq : 0.210, min_power_ratio : 0.02 }
-      filt4 : { min_freq : 0.240, max_freq : 0.305, min_power_ratio : 0.02 }
-      filt5 : { min_freq : 0.400, max_freq : 0.510, min_power_ratio : 0.01 }
-      filt6 : { min_freq : 0.580, max_freq : 0.620, min_power_ratio : 0.01 }
+      filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
+      filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
   config9:
     excluded_channels : [3]
     filters:
       filt1 : { min_freq : 0.000, max_freq : 1.000, min_power_ratio : 0.10 }
-      filt2 : { min_freq : 0.120, max_freq : 0.210, min_power_ratio : 0.02 }
-      filt3 : { min_freq : 0.245, max_freq : 0.280, min_power_ratio : 0.01 }
-      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.005 }
-      filt5 : { min_freq : 0.370, max_freq : 0.385, min_power_ratio : 0.02 }
-      filt6 : { min_freq : 0.385, max_freq : 0.410, min_power_ratio : 0.005 }
-      filt7 : { min_freq : 0.430, max_freq : 0.470, min_power_ratio : 0.01 }
-      filt8 : { min_freq : 0.495, max_freq : 0.510, min_power_ratio : 0.005 }
+      filt2 : { min_freq : 0.120, max_freq : 0.155, min_power_ratio : 0.02 }
+      filt3 : { min_freq : 0.245, max_freq : 0.255, min_power_ratio : 0.02 }
+      filt4 : { min_freq : 0.295, max_freq : 0.305, min_power_ratio : 0.011 }
+      filt5 : { min_freq : 0.398, max_freq : 0.408, min_power_ratio : 0.01 }
+      filt6 : { min_freq : 0.495, max_freq : 0.505, min_power_ratio : 0.01 }
 station4:
   config1:
     excluded_channels : [3, 7, 11, 15] # always exclude string 4


### PR DESCRIPTION
Previous filters cased a population of CP recoes to appear:
<img width="1505" height="846" alt="Screenshot 2025-09-09 at 12 24 04 PM" src="https://github.com/user-attachments/assets/80aad953-58b2-4fd6-8bbe-3b70d79d5b5c" />

Here, they are fixed with new filters:
<img width="1496" height="839" alt="Screenshot 2025-09-09 at 12 24 22 PM" src="https://github.com/user-attachments/assets/5bce7e9b-a554-44e6-b5fc-ae28102a1a01" />

See the effect on an example waveform:
<img width="1499" height="840" alt="Screenshot 2025-09-09 at 12 24 34 PM" src="https://github.com/user-attachments/assets/ca6df063-e3ea-4ac1-8fee-73efd23bc293" />
