### PR TITLE
Grey out masked channels

### DIFF
--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from araproc.framework import constants as const
 from araproc.framework import waveform_utilities as wu
 from araproc.framework import map_utilities as mu
 import ROOT
@@ -24,7 +25,7 @@ def get_wf_color(channel_number, excluded_channels):
       HPols (channel_number > 8), and a slightly greyer purple or green if the 
       channel is masked.
     """
-    if channel_number < 8: # Vpols
+    if channel_number in const.vpol_channel_ids: # Vpols
         if channel_number in excluded_channels: # Channel is masked
             return 'thistle'
         else:

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -17,10 +17,29 @@ But also, "agg" sometimes give segfaults, so instead we use "pdf".
 import matplotlib # noqa : E402
 matplotlib.use("pdf")
 
+def get_wf_color(channel_number, excluded_channels): 
+    """
+    Given a channel number and a list of excluded channels, return a purple 
+      color for all VPols (channel_number<8) in purple, a green color for
+      HPols (channel_number > 8), and a slightly greyer purple or green if the 
+      channel is masked.
+    """
+    if channel_number < 8: # Vpols
+        if channel_number in excluded_channels: # Channel is masked
+            return 'thistle'
+        else:
+            return 'purple'
+    else: # HPols
+        if channel_number in excluded_channels: # channel is masked
+            return '#c8d9bf' # A lighter version of "xkcd:greenish grey"
+        else: 
+            return 'green'
+
 def plot_waveform_bundle(
     waveform_dict,
     time_or_freq = "time",
-    output_file_path = None
+    output_file_path = None, 
+    excluded_channels = (),
     ):
     """
     Code to plot a bundle of waveforms.
@@ -94,12 +113,13 @@ def plot_waveform_bundle(
         ymin = min(ymin, yvals.min())
         ymax = max(ymax, yvals.max())
 
-        if wave_key < 8: # VPol channels
-            axd[f"ch{wave_key}"].plot(xvals, yvals, color = 'purple', lw = 1) # make the plot
-            axd[f"ch{wave_key}"].set_title(f"Channel {wave_key}")
-        else: # HPol channels
-            axd[f"ch{wave_key}"].plot(xvals, yvals, color = 'green', lw = 1) # make the plot
-            axd[f"ch{wave_key}"].set_title(f"Channel {wave_key}")
+        # make the plot
+        axd[f"ch{wave_key}"].plot(xvals, yvals, color=get_wf_color(wave_key, excluded_channels), lw = 1)
+        axd[f"ch{wave_key}"].set_title(f"Channel {wave_key}")
+
+        # Add warning to channels that are masked
+        if wave_key in excluded_channels: 
+            axd[f"ch{wave_key}"].annotate("Masked to Analysis", (0.03,0.87), xycoords='axes fraction', c='grey')
 
     # label axes  
     for ax in [axd["ch12"], axd["ch13"], axd["ch14"], axd["ch15"]]:


### PR DESCRIPTION
Add an argument to our `framework.data_visualization.plot_waveform_bundle()` function that lists a series of antennas to plot in a slightly grayed out color with the annotation "Masked to Analysis". For example if someone were to pass `excluded_channels=framework.dataset.AnalysisDataset.excluded_channels`, all channels masked to analysis would be plotted in greyed colors to help communicate to analyzers that the antennas did not contribute to analysis variable generation. Examples shown below: 

[station_2_run_18880_eventNo_47220_spectrum.pdf](https://github.com/user-attachments/files/22648500/station_2_run_18880_eventNo_47220_spectrum.pdf)
[station_2_run_18880_eventNo_47220_trace.pdf](https://github.com/user-attachments/files/22648505/station_2_run_18880_eventNo_47220_trace.pdf)
