### PR TITLE
updated raytraced with critical angle and detailed docstrings

### DIFF
--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 from araproc.framework import constants as const
 from araproc.framework import waveform_utilities as wu
 from araproc.framework import map_utilities as mu
+
 import ROOT
 ROOT.gStyle.SetOptStat(0)
 ROOT.gROOT.SetBatch(True) # tell root not to open gui windows
@@ -160,9 +161,11 @@ def plot_waveform_bundle(
     plt.close(fig)
     del fig, axd
 
+
+
 def plot_skymap(the_map,
                 plane_wave_elevation = None, 
-                station_id = None, landmarks = None,
+                station_id = None, map_type=None, radius_map = None, landmarks = None,
                 calpulser_indices = None, spice_depth = None,
                 aravertex_results = None,
                 output_file_path = None
@@ -253,24 +256,27 @@ def plot_skymap(the_map,
             av_label.Draw("SAME")
             labels.append(av_label)
  
-      
+    solution = 1 if map_type in {"distant_v_ref", "distant_h_ref"} else 0 
     ## Add known locations to the skymap 
-    landmark_dict = mu.AraGeom(station_id).get_known_landmarks(landmarks, calpulser_indices, spice_depth)
+    
+    landmark_dict = mu.AraGeom(station_id).get_known_landmarks(landmarks, radius_map, calpulser_indices, spice_depth, solution=solution)
 
     for entry in landmark_dict.keys():
-        if entry == 'critical_angle':
-           critical_ang = landmark_dict[entry]
-           horizontal_line = ROOT.TLine(-180, critical_ang, 180, critical_ang)  # Draw line from phi=-180 to phi=180 
-           horizontal_line.SetLineColor(ROOT.kRed)
-           horizontal_line.SetLineStyle(2)  # Dashed line
-           horizontal_line.SetLineWidth(2)
-           horizontal_line.Draw("SAME")
-           label1 = ROOT.TLatex(150,  critical_ang + 5, "#theta_{c}")  # Offset for clarity
-           label1.SetTextColor(ROOT.kRed)
-           label1.SetTextSize(0.03)
-           label1.Draw("SAME")
-           labels.append(label1)
-           continue
+        #adding ray-traced critical angle 
+        if entry == 'critical_angle_rt':
+            critical_ang_rt = landmark_dict[entry]
+            horizontal_line_rt = ROOT.TLine(-180, critical_ang_rt, 180, critical_ang_rt) # Draw line from phi=-180 to phi=180 
+            horizontal_line_rt.SetLineColor(ROOT.kRed)
+            horizontal_line_rt.SetLineStyle(2) # Dashed line
+            horizontal_line_rt.SetLineWidth(2) 
+            horizontal_line_rt.Draw("SAME")
+            label_rt = ROOT.TLatex(110, critical_ang_rt + 5, "#theta_{c}")  # Offset for clarity
+            label_rt.SetTextColor(ROOT.kRed)
+            label_rt.SetTextSize(0.03)
+            label_rt.Draw("SAME")
+            labels.append(label_rt)
+            continue
+
 
         phi = landmark_dict[entry][2]
         theta = landmark_dict[entry][1]
@@ -310,7 +316,8 @@ def plot_skymap(the_map,
     ROOT.gPad.SetRightMargin(0.15) # make space for the z axis
 
     # Add note about markers
-    caption = ROOT.TLatex(0.5, 0.92, "Correlations include ray tracings, markers are straight line paths")
+    caption_text = ("Correlations include ray tracings, markers are also ray-traced paths")
+    caption = ROOT.TLatex(0.5, 0.92, caption_text)
     caption.SetNDC(True)
     caption.SetTextAlign(22)
     caption.SetTextSize(0.025)

--- a/araproc/framework/data_visualization.py
+++ b/araproc/framework/data_visualization.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 from araproc.framework import constants as const
 from araproc.framework import waveform_utilities as wu
 from araproc.framework import map_utilities as mu
-
 import ROOT
 ROOT.gStyle.SetOptStat(0)
 ROOT.gROOT.SetBatch(True) # tell root not to open gui windows
@@ -36,6 +35,121 @@ def get_wf_color(channel_number, excluded_channels):
             return '#c8d9bf' # A lighter version of "xkcd:greenish grey"
         else: 
             return 'green'
+        
+def plot_waveform(
+    waveform_dict,
+    channel,
+    time_or_freq = "time",
+    output_file_path = None, 
+    excluded_channels = (),
+    ):
+    """
+    Code to plot a bundle of waveforms.
+    Please be aware that because this is matplotlib,
+    this function is very slow (about 2.5 s per event).
+    As a result, you probably shouldn't use it to draw many events.
+    It's meant for debugging and visualization.
+    """
+    
+    ####################
+    # sanitize inputs
+    ####################
+
+    # make sure they have requested something valid (time vs freq domain)
+    time_or_freq_options = ["time", "freq"]
+    if time_or_freq not in time_or_freq_options:
+        raise KeyError(f"Requested option ({time_or_freq}) is not in approved list: {time_or_freq_options}")
+
+    xlabel_options = {
+        "time" : "Time (ns)",
+        "freq" : "Frequency (GHz)"
+    }
+    ylabel_options = {
+        "time" : "Voltage (mV)",
+        "freq" : "Spectrum (dBm)"
+    }    
+
+    if not isinstance(output_file_path, str):
+        raise TypeError("Path to output file must be a string")
+        
+    ####################
+    # actually make plots
+    ####################
+
+    # get the waves to plot
+    tgraphs_to_plot = waveform_dict
+
+    # set up fig and axes
+    fig, ax = plt.subplots()
+
+    # draw the graphs, label each one appropriately
+    ymin = 1e100
+    ymax = -1e100
+    spec2Tot = {}
+    wave_key = channel
+    times, volts = wu.tgraph_to_arrays(tgraphs_to_plot[wave_key]) # 'times' in 'ns' and 'volts' in 'mV'
+    xvals = times
+    yvals = volts
+    
+    if time_or_freq == "freq":
+        # if they frequested frequency domain, do the FFT
+        freqs, spectrum = wu.time2freq(times, volts) # 'freqs' in 'GHz' and 'spectrum' (complex) in 'mV'
+        xvals = freqs
+        
+        # Convert yvals to dBm
+        # np.abs(spectrum)**2 makes spectrum in mV^2. For power, you do P = V^2/R , here R = Z_0 = 50 Ohm.
+        # mV**2/50 =  mW * 1e-3. Power is always reperesented as dBm in dB scale which is 10*log10(P in mW)
+        yvals = 10*np.log10(np.abs(spectrum)**2 / 50 / 1e3) # from mV to dBm
+        
+        # save total of square of absolute spectrum for reference
+        spec2Tot[f"ch{wave_key}"] = (np.abs(spectrum)**2).sum()
+
+    ymin = min(ymin, yvals.min())
+    ymax = max(ymax, yvals.max())
+
+    # make the plot
+    ax.plot(xvals, yvals, color=get_wf_color(wave_key, excluded_channels), lw = 1)
+    ax.set_title(f"Channel {wave_key}")
+
+    # Add warning to channels that are masked
+    if wave_key in excluded_channels: 
+        ax.annotate("Masked to Analysis", (0.03,0.87), xycoords='axes fraction', c='grey')
+
+    # label axes  
+    ax.set_xlabel(xlabel_options[time_or_freq])
+    ax.set_ylabel(ylabel_options[time_or_freq])
+    
+    # make limits look nice
+    if time_or_freq == "freq":
+        ax.set_xlim(0, 1)
+        # limit y range downwards
+        ymin = max(ymin, -25)
+        ax.set_ylim([ymin-5,ymax+5])
+
+        # add secondary axis to help with CW filtering
+        ax2 = ax.twinx()
+        y1min, y1max = ax.get_ylim()
+        ## convert back to just the spec^2
+        spec2min = 50.*1e3*10.**(y1min/10.)
+        spec2max = 50.*1e3*10.**(y1max/10.)
+        ## normalize by total power in spectrum
+        fmin = np.log10(spec2min/spec2Tot[f"ch{wave_key}"])
+        fmax = np.log10(spec2max/spec2Tot[f"ch{wave_key}"])
+        ax2.set_ylim(fmin, fmax)
+        ax2.set_yticks(np.arange(np.ceil(fmin), np.floor(fmax)+0.1, 1)) # ticks MUST fall within the [fmin, fmax] range or y-axes will not correspond correctly
+        ax2.axhline(y=0.0, c='lightgray', linestyle='--')
+        ax2.set_ylabel("lg(Fractional Power)")
+    else:
+        ax.set_ylim(ymin, ymax)
+    plt.tight_layout()
+
+    # save figure
+    fig.savefig(output_file_path)
+
+    # careful cleanup
+    plt.close(fig)
+    del fig, ax
+
 
 def plot_waveform_bundle(
     waveform_dict,
@@ -162,11 +276,13 @@ def plot_waveform_bundle(
     del fig, axd
 
 
-
 def plot_skymap(the_map,
-                plane_wave_elevation = None, 
-                station_id = None, map_type=None, radius_map = None, landmarks = None,
-                calpulser_indices = None, spice_depth = None,
+                plane_wave_elevation, 
+                station_id, 
+                map_type, 
+                landmarks = None,
+                calpulser_indices = None, 
+                spice_depth = None,
                 aravertex_results = None,
                 output_file_path = None
                 ):
@@ -256,13 +372,23 @@ def plot_skymap(the_map,
             av_label.Draw("SAME")
             labels.append(av_label)
  
+    # Reconstruction sphere radius 
+    if map_type in ["pulser_v", "pulser_h"]:
+        radius_map = float(const.calpulser_r_library[station_id])
+    else:
+        radius_map = float(const.distant_events_r_library[station_id])
+    
     solution = 1 if map_type in {"distant_v_ref", "distant_h_ref"} else 0 
-    ## Add known locations to the skymap 
+
+    # Add known locations to the skymap 
     
     landmark_dict = mu.AraGeom(station_id).get_known_landmarks(landmarks, radius_map, calpulser_indices, spice_depth, solution=solution)
+    marker_status = landmark_dict.get("_marker_status", {})
 
     for entry in landmark_dict.keys():
-        #adding ray-traced critical angle 
+    
+        if entry == "_marker_status":
+            continue
         if entry == 'critical_angle_rt':
             critical_ang_rt = landmark_dict[entry]
             horizontal_line_rt = ROOT.TLine(-180, critical_ang_rt, 180, critical_ang_rt) # Draw line from phi=-180 to phi=180 
@@ -280,12 +406,22 @@ def plot_skymap(the_map,
 
         phi = landmark_dict[entry][2]
         theta = landmark_dict[entry][1]
+        
         # Draw the marker
-        marker = ROOT.TMarker(phi, theta, 29)  # Style 29: Star
+        
+        status = marker_status.get(entry, "raytraced")
+        marker_style = 5 if status == "sl_fallback" else 29
+        marker = ROOT.TMarker(phi, theta, marker_style)
+
         color = ROOT.kBlack if "CP" in entry else ROOT.kRed
         marker.SetMarkerColor(color)
 
-        marker.SetMarkerSize(2.0)
+        # Set Markersize for SL fallback marker and Ray-Traced Marker
+        if status == "sl_fallback":
+            marker.SetMarkerSize(1.6)
+        else:
+            marker.SetMarkerSize(2.0)
+
         marker.Draw("SAME")
         markers.append(marker)
 
@@ -316,11 +452,14 @@ def plot_skymap(the_map,
     ROOT.gPad.SetRightMargin(0.15) # make space for the z axis
 
     # Add note about markers
-    caption_text = ("Correlations include ray tracings, markers are also ray-traced paths")
+    caption_text = (
+    "#lower[0.35]{#scale[2.0]{*}} : ray-traced direction;  "
+    "#scale[1.0]{#times} : straight-line fallback when no ray-traced solution is found"
+    )
     caption = ROOT.TLatex(0.5, 0.92, caption_text)
     caption.SetNDC(True)
     caption.SetTextAlign(22)
-    caption.SetTextSize(0.025)
+    caption.SetTextSize(0.030)
     caption.SetTextColor(ROOT.kRed)
     caption.Draw()
     labels.append(caption)

--- a/araproc/framework/map_utilities.py
+++ b/araproc/framework/map_utilities.py
@@ -272,10 +272,10 @@ class AraGeom:
 
         landmarks = []
         if landmark_type == "ICL":
-            for i in range(1):
-                corner = self.geomTool.getICLCorner(i)
+            for i in range(1):  ## This can go range(4)
+                corner = self.geomTool.getICLCorner(i)  
                 landmarks.append([corner[0], corner[1], corner[2]])
-        elif landmark_type == "WT":
+        elif landmark_type == "WT": ## This can go range(1,4)
             for i in range(3, 4):
                 corner = self.geomTool.getWindTurbine(i)
                 landmarks.append([corner[0], corner[1], corner[2]])
@@ -308,12 +308,12 @@ class AraGeom:
 
 
         if pulser_name == "SPIce" and spice_depth is None:
-            raise ValueError("Unknown SPIce pulser depth")
+            raise ValueError(f"Unknown SPIce pulser depth")
 
         pulser_coords = {
             "IC1S":  [45659.6457, 50490.4199],
-            "IC22S": [44884.416,  51444.8819],
-            "SPIce": [42600,      48800],
+            "IC22S": [44884.416, 51444.8819],
+            "SPIce": [42600, 48800],
         }
         pulser_depths = {"IC1S": -1400, "IC22S": -1450.47, "SPIce": spice_depth}
 

--- a/araproc/framework/map_utilities.py
+++ b/araproc/framework/map_utilities.py
@@ -4,7 +4,7 @@ import ROOT
 from araproc.framework import constants
 
 
-def get_corr_map_peak(the_map  = None):
+def get_corr_map_peak(the_map=None):
     """
     Little utility helper function
 
@@ -22,44 +22,125 @@ def get_corr_map_peak(the_map  = None):
     peak_phi : int
         The phi value of the peak of the correlation map
     """
-        
+
     if the_map is None:
-       raise Exception("No TH2D map was passed")
-    
-    _peakZ = ctypes.c_int()
+        raise Exception("No TH2D map was passed")
+
+    _peakZ     = ctypes.c_int()
     _peakTheta = ctypes.c_int()
-    _peakPhi = ctypes.c_int()
+    _peakPhi   = ctypes.c_int()
     the_map.GetMaximumBin(_peakPhi, _peakTheta, _peakZ)
 
-    peak_corr = the_map.GetMaximum()
-    peak_phi = the_map.GetXaxis().GetBinCenter(_peakPhi.value)
+    peak_corr  = the_map.GetMaximum()
+    peak_phi   = the_map.GetXaxis().GetBinCenter(_peakPhi.value)
     peak_theta = the_map.GetYaxis().GetBinCenter(_peakTheta.value)
     return peak_corr, peak_phi, peak_theta
 
 
+def load_raytrace_model(
+    arasimsrc="/cvmfs/icecube.opensciencegrid.org/users/abishop/AraSim-main"):
+    """
+    Load and initialize the AraSim ray-tracing model into ROOT's interpreter.
+
+    Sets up the exponential refractive index model n(z) = A - B*exp(-C*|z|)
+    with A=1.780, B=0.454 (= A - 1.326), C=0.0202 /m, and registers the
+    rt_doTrace_savePoints function that saves all ray-path (x, z) points
+    for sphere-crossing calculations. A, B, C parameters are same as in PA analysis paper
+
+    Parameters
+    ----------
+    arasimsrc : str
+        Path to the AraSim source directory containing RayTrace.h,
+        RayTrace_IceModels.h, and Vector.h.
+    """
+    ROOT.gInterpreter.ProcessLine(f'#include "{arasimsrc}/RayTrace.h"')
+    ROOT.gInterpreter.ProcessLine(f'#include "{arasimsrc}/RayTrace_IceModels.h"')
+    ROOT.gInterpreter.ProcessLine(f'#include "{arasimsrc}/Vector.h"')
+    ROOT.gInterpreter.ProcessLine('#include <vector>')
+
+    ROOT.gInterpreter.ProcessLine(
+        'auto _rt_atten = boost::shared_ptr<basicAttenuationModel>'
+        '(new basicAttenuationModel);'
+    )
+    ROOT.gInterpreter.ProcessLine(
+        f'auto _rt_refr = boost::shared_ptr<exponentialRefractiveIndex>'
+        f'(new exponentialRefractiveIndex({1.3260},{1.780},{0.0202}));'
+    )
+    ROOT.gInterpreter.ProcessLine('RayTrace::TraceFinder _rt_tf(_rt_refr, _rt_atten);')
+    ROOT.gInterpreter.ProcessLine('Vector _rt_src; Vector _rt_rec;')
+
+    ROOT.gInterpreter.Declare(r'''
+        #include <vector>
+
+        static std::vector<double> _rt_x;
+        static std::vector<double> _rt_z;
+        static std::vector<int>    _rt_stepType;
+
+        struct RTPointSaver {
+            void operator()(const RayTrace::fullRayPosition& p, RayTrace::RKStepType t) const {
+                _rt_x.push_back(p.x);
+                _rt_z.push_back(p.z);
+                _rt_stepType.push_back((int)t);
+            }
+        };
+
+        RayTrace::TraceRecord rt_doTrace_savePoints(
+            double src_depth,
+            double launch_theta,
+            const RayTrace::rayTargetRecord& target,
+            unsigned short allowedReflections,
+            double frequency,
+            double polarization,
+            int &sol_error
+        ){
+            _rt_x.clear();
+            _rt_z.clear();
+            _rt_stepType.clear();
+
+            RTPointSaver cb;
+
+            return _rt_tf.doTrace<RayTrace::fullRayPosition, RTPointSaver>(
+                src_depth, launch_theta, target, allowedReflections,
+                frequency, polarization, sol_error, cb
+            );
+        }
+
+        const std::vector<double>& rt_get_x(){ return _rt_x; }
+        const std::vector<double>& rt_get_z(){ return _rt_z; }
+        const std::vector<int>&    rt_get_stepType(){ return _rt_stepType; }
+    ''')
+
+    if not hasattr(ROOT, "rt_doTrace_savePoints"):
+        raise RuntimeError("Failed to declare rt_doTrace_savePoints in ROOT.")
+
+
+load_raytrace_model()
+
+
 class AraGeom:
+
     """
     A class to initialize ARA geometry and provide associated utility functions.
     """
 
-
     def __init__(self, station_id):
         """
         Initialize the geometry tool and station information.
+
+        Parameters
+        ----------
+        station_id : int
+            ARA station number (e.g. 1, 2, 3, 4, 5).
         """
-        # Constants
-        self.FEET_TO_METER = 0.3048  # Conversion factor from feet to meter
-        self.SUR_TO_GLOB = np.array([22400, 53900, -36.02])  # Survey to global offset in feet
+        self.FEET_TO_METER = 0.3048
+        self.SUR_TO_GLOB   = np.array([22400, 53900, -36.02])
 
         self.station_id = station_id
-        # Initialize the Geometry Tool
-        self.geomTool = ROOT.AraGeomTool.Instance()
-
-        # Station information
-        self.st_info = self.geomTool.getStationInfo(self.station_id)
-
+        self.geomTool   = ROOT.AraGeomTool.Instance()
+        self.st_info    = self.geomTool.getStationInfo(self.station_id)
 
     def get_station_center(self, excluded_channels=None):
+        
         """
         Calculates the average x, y, and z coordinates of antennas for a given station.
 
@@ -74,24 +155,22 @@ class AraGeom:
            station center (x, y, z) for given station
         """
 
+
         if excluded_channels is None:
             excluded_channels = []
 
-        antenna_coordinates = [[] for _ in range(3)]  # x, y, z
-        total_antennas = constants.num_rf_channels
-
-        for antenna_index in range(total_antennas):
+        antenna_coordinates = [[] for _ in range(3)]
+        for antenna_index in range(constants.num_rf_channels):
             if antenna_index in excluded_channels:
                 continue
-
             antenna_info = self.st_info.getAntennaInfo(antenna_index)
             for axis in range(3):
                 antenna_coordinates[axis].append(antenna_info.antLocation[axis])
-        av_ant_position = tuple(np.average(coords) for coords in antenna_coordinates)
-        return av_ant_position
 
+        return tuple(np.average(coords) for coords in antenna_coordinates)
 
     def get_local_CP(self, list_of_cal_pulser_indices):
+
         """
         Parameters
         ----------
@@ -109,7 +188,6 @@ class AraGeom:
             cal_pulser_info = self.st_info.getCalAntennaInfo(int(cal_index))
             calpulsers[f'{cal_index}'] = [cal_pulser_info.antLocation[i] for i in range(3)]
         return calpulsers
-
 
     def get_survey_to_global_coords(self, easting, northing, elevation=None):
         """
@@ -132,13 +210,30 @@ class AraGeom:
         if elevation is not None:
             return np.asarray([easting, northing, elevation]) - self.SUR_TO_GLOB
         return np.asarray([easting, northing]) - self.SUR_TO_GLOB[:2]
-    
-    def get_array_from_lat_long(self,latitude,longitude):
-        easting = self.geomTool.getEastingFromLatLong(latitude,longitude)
-        northing = self.geomTool.getNorthingFromLatLong(latitude,longitude)
-        return np.array([northing, easting,0])
+
+    def get_array_from_lat_long(self, latitude, longitude):
+        """
+        Convert latitude/longitude to ARA array coordinates.
+
+        Parameters
+        ----------
+        latitude : float
+            Latitude in decimal degrees.
+        longitude : float
+            Longitude in decimal degrees.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array coordinates [northing, easting, 0], in meters.
+        """
+
+        easting  = self.geomTool.getEastingFromLatLong(latitude, longitude)
+        northing = self.geomTool.getNorthingFromLatLong(latitude, longitude)
+        return np.array([northing, easting, 0])
 
     def get_global_to_station_centric(self, array_coords):
+
         """
         Convert global coordinates to station-centric coordinates.
 
@@ -150,14 +245,13 @@ class AraGeom:
         Returns
         -------
         - output_coords: numpy array
-          Station-centric coordinates [x', y', z'].
+          Station-centric coordinates [x', y', z'] in meters.
         """
 
-        input_coords = np.array(array_coords, dtype=np.float64)
+        input_coords  = np.array(array_coords, dtype=np.float64)
         output_coords = np.zeros(3, dtype=np.float64)
         self.geomTool.convertArrayToStationCoords(self.station_id, input_coords, output_coords)
         return output_coords
-
 
     def get_southpole_landmarks(self, landmark_type):
         """
@@ -175,12 +269,13 @@ class AraGeom:
             The landmark location in ARA Gloabal (Array) Coordinate system
         """
 
+
         landmarks = []
         if landmark_type == "ICL":
-            for i in range(1):  ## This can go range(4)
+            for i in range(1):
                 corner = self.geomTool.getICLCorner(i)
                 landmarks.append([corner[0], corner[1], corner[2]])
-        elif landmark_type == "WT":  ## This can go range(1,4)
+        elif landmark_type == "WT":
             for i in range(3, 4):
                 corner = self.geomTool.getWindTurbine(i)
                 landmarks.append([corner[0], corner[1], corner[2]])
@@ -192,7 +287,6 @@ class AraGeom:
         else:
             raise ValueError(f"Unknown landmark type: {landmark_type}")
         return landmarks
-
 
     def get_distant_pulsers(self, pulser_name, spice_depth=None):
         """
@@ -212,25 +306,28 @@ class AraGeom:
           X, Y, Z location of pulser in station centric
         """
 
+
         if pulser_name == "SPIce" and spice_depth is None:
-            raise ValueError(f"Unknown SPIce pulser depth")
+            raise ValueError("Unknown SPIce pulser depth")
+
         pulser_coords = {
-            "IC1S": [45659.6457, 50490.4199],
-            "IC22S": [44884.416, 51444.8819],
-            "SPIce": [42600, 48800],
+            "IC1S":  [45659.6457, 50490.4199],
+            "IC22S": [44884.416,  51444.8819],
+            "SPIce": [42600,      48800],
         }
         pulser_depths = {"IC1S": -1400, "IC22S": -1450.47, "SPIce": spice_depth}
+
         if pulser_name not in pulser_coords:
             raise ValueError(f"Unknown pulser name: {pulser_name}")
 
         easting, northing = pulser_coords[pulser_name]
         global_coords = self.get_survey_to_global_coords(easting, northing) * self.FEET_TO_METER
         global_coords = [float(global_coords[0]), float(global_coords[1]), 0]
-        st_centric_coords = self.get_global_to_station_centric(global_coords)
-        return st_centric_coords[0], st_centric_coords[1], pulser_depths[pulser_name]
-
+        st_centric    = self.get_global_to_station_centric(global_coords)
+        return st_centric[0], st_centric[1], pulser_depths[pulser_name]
 
     def get_relative_cartesian_to_spherical(self, reference_point, target_point):
+
         """
         Compute the spherical coordinates of a vector defined by two Cartesian points.
 
@@ -255,14 +352,13 @@ class AraGeom:
             The azimuth angle (phi) in degrees, measured from the x-axis in the xy-plane.
         """
 
-        delta = np.array(target_point) - np.array(reference_point)
-        x, y, z = delta
-        r = np.sqrt(x**2 + y**2 + z**2)
-        theta = np.degrees(np.arccos(z / r))
-        phi = np.degrees(np.arctan2(y, x))
+
+        delta    = np.array(target_point) - np.array(reference_point)
+        x, y, z  = delta
+        r        = np.sqrt(x**2 + y**2 + z**2)
+        theta    = np.degrees(np.arccos(z / r))
+        phi      = np.degrees(np.arctan2(y, x))
         return r, 90 - theta, phi
-
-
 
     def get_critical_angle(self):
         """
@@ -271,67 +367,544 @@ class AraGeom:
         critical angle in terms of elevation angle
 
         """
-        station_depth = self.get_station_center()[2]
-        n_air = constants.get_index_of_refraction(1e-3)
-        n_ice = constants.get_index_of_refraction(station_depth)
-        critical_angle = np.arcsin(n_air/n_ice)
-        critical_angle *= (180/np.pi)
+        
+        station_depth  = self.get_station_center()[2]
+        n_air          = constants.get_index_of_refraction(1e-3)
+        n_ice          = constants.get_index_of_refraction(station_depth)
+        critical_angle = np.arcsin(n_air / n_ice)
+        return 90 - np.degrees(critical_angle)
 
-        return 90 - critical_angle  ## In terms of elevation angle
-
-
-    def get_known_landmarks(self, list_of_landmarks=None, list_of_cal_pulser_indices=None, spice_depth=None):
+    def get_raytraced_sphere_crossing_angles(
+        self,
+        source_xyz,
+        R_sphere,
+        accuracy=0.001,
+        solution=0,
+        frequency=0.5,
+        polarization=0.0,
+        station_center=None,
+    ):
         """
+        Find the apparent direction of a source on a reconstruction sphere via ray tracing.
+
+        The source is ray traced to the station center using AraSim's TraceFinder.
+        The selected ray branch is then intersected with a sphere of radius R_sphere(depending on --map_type)
+        centered on the station. This sphere crossing defines the apparent direction
+        (elevation, azimuth) that should be overlaid on the sky map.
+
+        If the traced path does not itself cross R_sphere (e.g. source is closer than
+        R_sphere, or the path curves away), the outermost traced point and its local
+        direction are used to extend the ray outward until it intersects the sphere
+        (backward extension). If the result is still unphysical (elevation outside
+        [-90, 90]), the straight-line direction is returned as a fallback.
+
+        Ray solutions are identified by propagation-time ordering:
+          - Shortest TOF  → label 'D' (direct)
+          - Second TOF    → label 'R' (surface-reflected / refracted)
+
         Parameters
         ----------
-        list_of_cal_pulser_indices : list ## example [0,1,2,3]
-          which calpulsers you want to see in your skymap
-        list_of_landmarks: list ## example ['ICL','IC22S','SPT','IC1S','SPIce','WT']
-          which landmarks you want to see in your skymap
-        spice_depth : int/float
-          the depth of spice pulser ## example -1451.3 
+        source_xyz : array-like
+            Source position [x, y, z] in station-centric Cartesian coordinates, in meters.
+        R_sphere : float
+            Radius of the reconstruction sphere, in meters.
+        accuracy : float, optional
+            Ray-tracing convergence accuracy passed to AraSim findPaths. Default 0.001.
+        solution : int, optional
+            Requested solution type:
+              - 0 : direct path (shortest propagation time)
+              - 1 : reflected/refracted path (second-shortest propagation time)
+            If solution=1 and findPaths returns only 1 solution, returns [] immediately
+            so the caller can fall back to the straight-line direction.
+        frequency : float, optional
+            Signal frequency passed to AraSim ray tracer, in GHz. Default 0.5 GHz.
+        polarization : float, optional
+            Signal polarization passed to AraSim ray tracer, in radians. Default 0.0.
+        station_center : array-like or None, optional
+            Station center [x, y, z] in station-centric Cartesian coordinates, in meters.
+            
+
+        Returns
+        -------
+        list of dict
+            Empty list if ray tracing fails or no valid sphere crossing is found.
+            Otherwise a single-element list with keys:
+              - 'label'       : str, 'D' or 'R'
+              - 'elevation'   : float, elevation angle on R_sphere in degrees [-90, +90]
+              - 'azimuth'     : float, azimuth angle in degrees [-180, +180]
+              - 'tof'         : float, propagation time in nanoseconds
+              - 'path_len'    : float, path length in meters
+              - 'allowedUsed' : int, AraSim reflection mode flag
+        """
+
+        src = np.asarray(source_xyz, dtype=float)
+        rec = np.asarray(station_center if station_center is not None else self.get_station_center(), dtype=float)
+        R = float(R_sphere) # radius of the map
+
+        z_src  = float(src[2])
+        z_rec  = float(rec[2])
+
+        dx     = float(src[0] - rec[0])
+        dy     = float(src[1] - rec[1])
+        r_src  = float(np.hypot(dx, dy))
+        az_phi = float(np.arctan2(dy, dx))
+
+        
+        ROOT._rt_src.SetXYZ(r_src, 0.0, z_src)
+        ROOT._rt_rec.SetXYZ(0.0,   0.0, z_rec)
+
+        def _circle_intersect(p0, v, radius, t_max=np.inf):
+
+            """
+            Find the first intersection of p(t) = p0 + t*v with the
+            station-centered circle x^2 + z^2 = radius^2 in the local
+            propagation plane, where:
+              - x >= 0 : radial distance from station, in meters
+              - z      : vertical offset from station, in meters (positive upward)
+
+            Parameterizes the path as p(t) = p0 + t*v and substitutes into
+            the circle equation to get the quadratic a*t^2 + b*t + c = 0:
+              a = |v|^2
+              b = 2 * dot(p0, v)
+              c = |p0|^2 - radius^2
+            
+            The quadratic has two roots t1 (smaller) and t2 (larger).
+            t1 is the entry point into the circle, t2 is the exit point.
+            We iterate smallest-first so we always return the nearest valid crossing.
+            The two roots t1, t2 are the candidate intersections. Only roots
+            with 0 <= t <= t_max  (lies on the segment (t_max=1) or forward ray (t_max=inf))
+            and 
+            x >= 0 are physically valid. (physically valid radial coordinate (radius cannot be negative))
+
+            Used in two modes:
+              - Segment (forward crossing):  t_max=1.0, v = p1 - p0
+              - Ray (backward extension):    t_max=inf, v = local direction at p_far
+
+            Parameters
+            ----------
+            p0 : tuple
+                Start point (x, z) in meters.
+            v : tuple
+                Direction vector (vx, vz) in meters. For a segment, pass p1-p0.
+            radius : float
+                Circle radius in meters (= R_sphere).
+            t_max : float, optional
+                Upper bound on t. Default inf (semi-infinite ray).
+
+            Returns
+            -------
+            tuple or None
+                (x, z, t) of the first valid intersection in meters, or None.
+            """
+            
+            x0, z0 = p0  # start point components
+            vx, vz = v  # direction vector components
+            a = vx*vx + vz*vz  # quadratic coefficient: |v|^2
+            if a == 0.0:
+                return None                         # zero-length direction vector, no intersection possible
+            b    = 2.0*(x0*vx + z0*vz)              # quadratic coefficient: 2*dot(p0, v)
+            c    = x0*x0 + z0*z0 - radius*radius    # quadratic coefficient: |p0|^2 - R^2
+            disc = b*b - 4.0*a*c                    # discriminant: negative means no real intersection
+            if disc < 0.0:
+                return None                                 # ray misses the circle entirely
+            sq = np.sqrt(disc)                               # square root of discriminant
+            for t in ((-b - sq)/(2.0*a), (-b + sq)/(2.0*a)):   # t1 (near), t2 (far) roots, smallest first
+                if 0.0 <= t <= t_max:                 # t must lie on segment (t_max=1) or forward ray (t_max=inf)
+                    x, z = x0 + t*vx, z0 + t*vz       # intersection point
+                    if x >= 0.0:                      # x >= 0 required: radial distance cannot be negative
+                        return (x, z, t)              # return first valid crossing
+            return None
+
+        """
+        findPaths from source to station: AraSim searches for all ray solutions in its 2D cylindrical propagation plane (x = horizontal radial distance
+        from source, z = depth). Returns up to 2 solutions ordered by TOF:
+          sol[0] -> direct path (D)   : shortest propagation time, travels directly
+                                         through ice from source to station
+          sol[1] -> reflected path (R): second-shortest, reflects off the ice surface
+                                         before reaching the station
+        """
+
+        sol_cnt = ctypes.c_int()
+        sol_err = ctypes.c_int()
+        paths   = ROOT._rt_tf.findPaths(
+            ROOT._rt_src, ROOT._rt_rec,
+            float(frequency), ROOT.TMath.Pi() / 2,
+            sol_cnt, sol_err,
+            int(ROOT.RayTrace.SurfaceReflection), float(accuracy),
+        )
+
+        self._last_rt_npaths      = 0
+        self._last_rt_paths       = []
+        self._last_rt_fail_reason = None
+
+
+        if sol_err.value != 0 or not paths or len(paths) == 0:
+            self._last_rt_fail_reason = (
+                f"findPaths error (serr={sol_err.value})"
+                if sol_err.value != 0
+                else "findPaths returned zero solutions"
+            )
+            return []
+
+
+        sorted_paths = sorted(paths, key=lambda p: float(p.pathTime))
+
+        self._last_rt_npaths = len(sorted_paths)
+        self._last_rt_paths  = [
+            {"tof": float(p.pathTime)*1e9, "path_len": float(p.pathLen),
+             "launchAngle": float(p.launchAngle)}
+            for p in sorted_paths
+        ]
+
+
+
+        # Label by TOF: shortest=D, second=R
+        labeled = []
+        if len(sorted_paths) >= 1: labeled.append((sorted_paths[0], "D"))
+        if len(sorted_paths) >= 2: labeled.append((sorted_paths[1], "R"))
+
+        if solution == 0:
+            to_trace = [(p, l) for p, l in labeled if l == "D"]
+        elif solution == 1:
+            to_trace = [(p, l) for p, l in labeled if l == "R"]
+            if not to_trace:
+                # Only 1 solution from ray tracer — R simply does not exist
+                #print(" [INFO] R solution not found: findPaths returned only 1 solution")
+                self._last_rt_fail_reason = "R solution not found: only 1 ray-trace solution exists"
+                return []
+  
+
+        allowed_used = int(ROOT.RayTrace.SurfaceReflection)
+
+        # Straight-line fallback (used only if RT elevation is unphysical)
+
+        _, elev_sl, az_sl = self.get_relative_cartesian_to_spherical(rec, src)
+
+        out = []
+        for path, label in to_trace:
+            sol_error = ctypes.c_int(0)
+            ROOT.rt_doTrace_savePoints(
+                z_src, float(path.launchAngle),
+                ROOT.RayTrace.rayTargetRecord(z_rec, r_src),
+                allowed_used, float(frequency), float(polarization), sol_error,
+            )
+
+            xs = np.asarray(list(ROOT.rt_get_x()), dtype=float)
+            zs = np.asarray(list(ROOT.rt_get_z()), dtype=float)
+
+            if sol_error.value != 0 or len(xs) < 2:
+                print(f" [TRACE FAIL] label={label}  sol_error={sol_error.value}  npts={len(xs)}")
+                continue
+
+            # Receiver-centered coordinates in the local propagation plane
+            xp       = r_src - xs       # radial distance from station, meters
+            dz       = zs - z_rec       # vertical offset from station, meters
+            d_to_rec = np.hypot(xp, dz) # distance from station along path, meters
+
+            # Forward crossing: find where path crosses R_sphere outward from station
+            # i_cross is the index where d steps from outside (d>=R) to inside (d<R)
+            i_cross = next(
+                (i for i in range(len(d_to_rec)-1, 0, -1)
+                 if d_to_rec[i] <= R < d_to_rec[i-1]),
+                None
+            )
+
+            if i_cross is not None:
+                p_out = (float(xp[i_cross-1]), float(dz[i_cross-1])) # point just outside R_sphere
+                p_in  = (float(xp[i_cross]),   float(dz[i_cross]))   # point just inside R_sphere
+                inter = _circle_intersect( 
+                    p_out, (p_in[0]-p_out[0], p_in[1]-p_out[1]), R, t_max=1.0)   # interpolate exact crossing on segment
+                
+            else:
+                
+                # Path never reaches R_sphere — source is inside R_sphere or path curves away.
+                # Extend the ray from the outermost traced point using its local direction.
+                imax          = int(np.argmax(d_to_rec))    # index of point farthest from station
+                i_far, i_near = (0, 1) if imax == 0 else (imax, imax-1)     # far point and its neighbor for direction
+                p_far         = (float(xp[i_far]),  float(dz[i_far]))       # outermost traced point
+                p_near        = (float(xp[i_near]), float(dz[i_near]))      # neighbor point, defines local ray direction
+                v_ext         = (p_far[0]-p_near[0], p_far[1]-p_near[1])    # local direction vector at p_far
+                inter         = _circle_intersect(p_far, v_ext, R)        # extend ray until it hits R_sphere
+
+            if inter is None:
+                # Neither forward crossing nor backward extension reached R_sphere
+                self._last_rt_fail_reason = (
+                    f"no valid crossing/extension to R_sphere={R:.3f} m survived")
+                continue
+
+            xp_c, dz_c, _ = inter   # unpack crossing coordinates, discard t
+            elev = np.degrees(np.arctan2(dz_c, xp_c)) # elevation angle at sphere crossing, degrees
+            az   = np.degrees(az_phi)                       # azimuth angle
+
+            if not (-90.0 <= elev <= 90.0):
+                elev, az = elev_sl, az_sl   # unphysical elevation — fall back to straight-line
+
+            out.append({
+                "label"      : label,
+                "elevation"  : float(elev),
+                "azimuth"    : float(az),
+                "tof"        : float(path.pathTime) * 1e9,
+                "path_len"   : float(path.pathLen),
+                "allowedUsed": allowed_used,
+            })
+
+        if not out:
+            self._last_rt_fail_reason = (
+                f"no valid crossing/extension to R_sphere={R:.3f} m survived")
+
+        return out
+
+    
+    def get_raytraced_critical_angle(self, R_sphere):
+
+        """
+        Map the critical reception angle onto the reconstruction sphere via ray tracing.
+
+        Integrates the critical-angle ray upward from the station through the ice
+        using the Snell invariant n(z)*sin(theta) = n_air. The refractive index
+        n(z) is evaluated at each step via constants.get_index_of_refraction(z)
+        — no hardcoded ice model parameters.
+
+        Two successful exit conditions:
+          1. Ray crosses R_sphere within ice: returns the crossing elevation.
+          2. Ray exits ice (z=0) before reaching R_sphere: returns the elevation
+             of the surface-exit point. This occurs for large R_sphere (e.g. 300 m)
+             where the ray reaches the surface before the sphere boundary.
+
+        Falls back to get_critical_angle() (geometric, no ray bending) if:
+          - sin(theta) >= 1 is encountered during integration, meaning the ray
+            cannot propagate upward from that depth.
+          - The sphere-crossing elevation is outside [-90, 90] degrees.
+          - The integration loop exits without finding any crossing.
+
+        Parameters
+        ----------
+        R_sphere : float
+            Reconstruction sphere radius, in meters.
+
+        Returns
+        -------
+        float
+            Elevation angle in degrees where the critical-angle ray appears on
+            the reconstruction sphere. Range: [0, 90].
+            Returns get_critical_angle() on any failure.
+        """
+
+        z_rec  = float(self.get_station_center()[2])
+        R = float(R_sphere)
+        n_air  = constants.get_index_of_refraction(1e-3)
+        #n_ice  = constants.get_index_of_refraction(z_rec)
+
+        dz_step = 0.1  # integration step, meters 
+        z_prev, r_prev, d_prev = z_rec, 0.0, 0.0
+
+        while z_prev < 0.0:
+            z_curr = z_prev + dz_step
+            n_z    = constants.get_index_of_refraction(z_prev + 0.5*dz_step)
+            sin_th = n_air / n_z
+
+            if sin_th >= 1.0:
+                return float(self.get_critical_angle())
+
+            r_curr  = r_prev + (sin_th / np.sqrt(1.0 - sin_th**2)) * dz_step
+            dz_curr = z_curr - z_rec
+            d_curr  = np.hypot(r_curr, dz_curr)
+
+ 
+            # Case 1: ray crosses R_sphere while still in ice
+            if d_prev <= R < d_curr:
+                frac     = (R - d_prev) / (d_curr - d_prev)          # fraction along step where d = R exactly
+                r_cross  = r_prev + frac*(r_curr - r_prev)            # horizontal radial distance at crossing, meters
+                dz_cross = (z_prev + frac*(z_curr - z_prev)) - z_rec  # vertical offset from station at crossing, meters
+                elev     = float(np.degrees(np.arctan2(dz_cross, r_cross)))  # elevation angle at crossing, degrees
+                if not (-90.0 <= elev <= 90.0):
+                    return float(self.get_critical_angle())
+                return elev
+
+            # Case 2: ray exits ice surface (z=0) before reaching R_sphere
+            if z_prev <= 0.0 <= z_curr:
+                frac   = (0.0 - z_prev) / (z_curr - z_prev)  # fraction along step where z = 0 exactly
+                r_surf = r_prev + frac*(r_curr - r_prev)      # horizontal radial distance at surface exit, meters
+                elev   = float(np.degrees(np.arctan2(-z_rec, r_surf)))  # elevation using station depth as vertical leg, degrees
+                if not (-90.0 <= elev <= 90.0):
+                    return float(self.get_critical_angle())
+                return elev
+
+            z_prev, r_prev, d_prev = z_curr, r_curr, d_curr
+
+        return float(self.get_critical_angle()) # return the default critical angle if crossing case 1 and 2 fail
+
+
+
+    def get_known_landmarks(
+        self,
+        list_of_landmarks=None,
+        R_map=None,
+        list_of_cal_pulser_indices=None,
+        spice_depth=None,
+        solution=None,
+    ):
+        """
+        Compute apparent directions of known landmarks on a reconstruction sphere.
+
+        Each landmark is ray traced to the station and its direction is mapped onto
+        the reconstruction sphere of radius R_map. The ray tracer (AraSim findPaths)
+        always returns at least 1 solution for all landmarks and all stations tested.
+        Solutions are ordered by propagation time (TOF):
+          - Shortest TOF  -> Direct path (D)  : travels straight through ice
+          - Second TOF    -> Reflected path (R): reflects off the ice surface
+
+        Which solution is shown on the map depends on the map type:
+          - direct maps   (e.g. pulser_*, distant_*_dir) : solution=0, shows D
+          - reflected maps (e.g. distant_*_ref)           : solution=1, shows R
+
+        Fallback rules:
+          - D solution: shown on map unless the traced path never crosses R_map.
+            This can happen if the source is closer to the station than R_map
+            AND the backward extension of the path also fails to reach R_map
+            (e.g. source inside R_map with a nearly vertical path). Falls back
+            to straight-line (SL) direction in that case.
+
+          - R solution: shown on map if findPaths returns 2 solutions AND the
+            reflected path crosses R_map. Falls back to SL if:
+              (a) findPaths returns only 1 solution — the reflected path
+                  physically does not exist for this source-station geometry, OR
+              (b) the reflected path never crosses R_map — same geometric
+                  condition as the D fallback above.
+
+        Parameters
+        ----------
+        list_of_landmarks : list of str, optional
+            Landmark names to include. Supported values:
+            'ICL', 'IC22S', 'SPT', 'IC1S', 'SPIce', 'WT', 'SPRESSO'.
+            Pass ['all'] to include all of the above.
+            Default: ['IC22S', 'ICL', 'SPRESSO'].
+        R_map : float
+            Reconstruction sphere radius corresponding to the map, in meters.
+        list_of_cal_pulser_indices : list of int, optional
+            Calpulser indices to include, e.g. [0, 1, 2, 3].
+            Pass ['all'] for all four. Default: [1, 3].
+        spice_depth : float, optional
+            Depth of the SPIce pulser in meters. Required if 'SPIce' is in
+            list_of_landmarks.
+        solution : int
+            Requested ray solution:
+              - 0 : direct path (shortest propagation time), for direct maps
+              - 1 : reflected path (second-shortest propagation time), for reflected maps
 
         Returns
         -------
         collect : dict
-           a dictionary that contains radius, elevation, and azimuth of different sources
+            Keys are landmark name strings. Values are [r, elevation, azimuth]
+            where r is the straight-line distance in meters, elevation and
+            azimuth are the ray-traced (or SL fallback) angles in degrees.
+            Also includes:
+              - 'critical_angle'    : geometric critical elevation angle, in degrees
+              - 'critical_angle_rt' : ray-traced critical elevation angle mapped
+                                      onto R_map, in degrees
         """
+        
 
         if list_of_landmarks is None:
             list_of_landmarks = ["IC22S", "ICL", "SPRESSO"]
-        elif list_of_landmarks == ['all']:
-             list_of_landmarks = ['ICL','IC22S','SPT','IC1S','WT','SPRESSO']   
+        elif list_of_landmarks == ["all"]:
+            list_of_landmarks = ["ICL", "IC22S", "SPT", "IC1S", "WT", "SPRESSO"]
+
         if list_of_cal_pulser_indices is None:
-            list_of_cal_pulser_indices = [1,3]
-        elif list_of_cal_pulser_indices == ['all']:
-             list_of_cal_pulser_indices = [0,1,2,3]
-        if spice_depth is not None:
-           list_of_landmarks.append('SPIce')
+            list_of_cal_pulser_indices = [1, 3]
+        elif list_of_cal_pulser_indices == ["all"]:
+            list_of_cal_pulser_indices = [0, 1, 2, 3]
+
+        if spice_depth is not None and "SPIce" not in list_of_landmarks:
+            list_of_landmarks.append("SPIce")
+
         collect = {}
-        
-        calpulser = self.get_local_CP(list_of_cal_pulser_indices)
         station_center = self.get_station_center()
+        
+
+        def _resolve(name, source_xyz, station_center, R_sphere, solution):
+
+            """
+            Resolve one landmark to its apparent direction on the reconstruction sphere.
+
+            Computes the straight-line (SL) direction first — this is always valid
+            and serves as the fallback. Then attempts ray tracing via
+            get_raytraced_sphere_crossing_angles(). Falls back to SL with diagnostic
+            output if ray tracing fails for any of the reasons documented in
+            get_known_landmarks().
+
+
+            Parameters
+            ----------
+            name : str
+                Landmark label used for diagnostic printing and as the collect key.
+            source_xyz : array-like
+                Source position [x, y, z] in station-centric Cartesian coordinates,
+                in meters.
+            station_center : array-like
+                Station center [x, y, z] in station-centric Cartesian coordinates,
+                in meters. 
+
+            R_sphere : float
+                Reconstruction sphere radius, in meters.
+
+            solution : int
+                0 = direct path, 1 = reflected path. See get_known_landmarks().
+
+            Returns
+            -------
+            list
+                [r, elevation, azimuth] where r is the SL distance in meters,
+                and elevation and azimuth are in degrees. Ray-traced if successful,
+                straight-line fallback otherwise.
+
+            """
+            r_sl, elev_sl, az_sl = self.get_relative_cartesian_to_spherical(
+                station_center, source_xyz
+            )
+
+
+            rt_sols = self.get_raytraced_sphere_crossing_angles(
+                source_xyz    = source_xyz,
+                R_sphere      = R_sphere,
+                solution      = solution,
+                station_center= station_center,
+            )
+
+            if not rt_sols:
+                return [r_sl, elev_sl, az_sl] # Fallback to SL solution
+            
+            return [r_sl, rt_sols[0]["elevation"], rt_sols[0]["azimuth"]] #always the requested solution, either D or R.
+
+
+        
+        # Local Calpulsers
+
+        calpulser = self.get_local_CP(list_of_cal_pulser_indices)
         for cp in calpulser:
-            rCal, tCal, pCal = self.get_relative_cartesian_to_spherical(station_center, calpulser[cp])
-            collect[f"CP{cp}"] = [rCal, tCal, pCal]
-            del rCal, tCal, pCal
+            collect[f"CP{cp}"] = _resolve(f"CP{cp}", calpulser[cp], station_center, R_map, solution)
         del calpulser
-          
-        for pulser in ["IC1S", "IC22S", "SPIce"]:
+        
+        # Distant pulsers
+
+        for pulser in ["IC22S", "IC1S", "SPIce"]:
             if pulser in list_of_landmarks:
                 this_pulser = self.get_distant_pulsers(pulser, spice_depth)
-                r, t, p = self.get_relative_cartesian_to_spherical(station_center, this_pulser)
-                collect[pulser] = [r, t, p]
-                del r,t,p 
+                collect[pulser] = _resolve(pulser, this_pulser, station_center, R_map, solution)
+
+        # South Pole surface landmarks
 
         for known_loc in ["ICL", "WT", "SPRESSO", "SPT"]:
             if known_loc in list_of_landmarks:
-                this_loc = self.get_southpole_landmarks(known_loc)
-                this_loc = np.array(this_loc)[0]
+                this_loc   = np.array(self.get_southpole_landmarks(known_loc))[0]
                 st_centric = self.get_global_to_station_centric(this_loc[:3])
-                r, t, p = self.get_relative_cartesian_to_spherical(station_center, st_centric)
-                collect[known_loc] = [r, t, p]
-                del r,t,p
-        collect['critical_angle'] = self.get_critical_angle()
-        return collect
+                if known_loc == "SPT":
+                    st_centric[2] = 7.55984245e-02  # corrected SPT depth, meters, set to ICL depth 
+                collect[known_loc] = _resolve(known_loc, st_centric, station_center, R_map, solution)
 
+        
+        # Critical angle (ray traced and fall back SL solution)
+
+        collect["critical_angle_rt"] = self.get_raytraced_critical_angle(R_map)
+
+        return collect

--- a/araproc/framework/map_utilities.py
+++ b/araproc/framework/map_utilities.py
@@ -1,10 +1,11 @@
 import ctypes
 import numpy as np
 import ROOT
+import os
 from araproc.framework import constants
 
 
-def get_corr_map_peak(the_map=None):
+def get_corr_map_peak(the_map  = None):
     """
     Little utility helper function
 
@@ -22,60 +23,108 @@ def get_corr_map_peak(the_map=None):
     peak_phi : int
         The phi value of the peak of the correlation map
     """
-
+        
     if the_map is None:
-        raise Exception("No TH2D map was passed")
-
-    _peakZ     = ctypes.c_int()
+       raise Exception("No TH2D map was passed")
+    
+    _peakZ = ctypes.c_int()
     _peakTheta = ctypes.c_int()
-    _peakPhi   = ctypes.c_int()
+    _peakPhi = ctypes.c_int()
     the_map.GetMaximumBin(_peakPhi, _peakTheta, _peakZ)
 
-    peak_corr  = the_map.GetMaximum()
-    peak_phi   = the_map.GetXaxis().GetBinCenter(_peakPhi.value)
+    peak_corr = the_map.GetMaximum()
+    peak_phi = the_map.GetXaxis().GetBinCenter(_peakPhi.value)
     peak_theta = the_map.GetYaxis().GetBinCenter(_peakTheta.value)
     return peak_corr, peak_phi, peak_theta
 
 
-def load_raytrace_model(
-    arasimsrc="/cvmfs/icecube.opensciencegrid.org/users/abishop/AraSim-main"):
+
+def load_raytrace_model(arasimsrc=None):
     """
     Load and initialize the AraSim ray-tracing model into ROOT's interpreter.
 
     Sets up the exponential refractive index model n(z) = A - B*exp(-C*|z|)
     with A=1.780, B=0.454 (= A - 1.326), C=0.0202 /m, and registers the
     rt_doTrace_savePoints function that saves all ray-path (x, z) points
-    for sphere-crossing calculations. A, B, C parameters are same as in PA analysis paper
+    for reconstruction-sphere crossing calculations.
 
     Parameters
     ----------
-    arasimsrc : str
+    arasimsrc : str or None
         Path to the AraSim source directory containing RayTrace.h,
-        RayTrace_IceModels.h, and Vector.h.
+        RayTrace_IceModels.h, and Vector.h. If None, the path is taken
+        from the ARA_SIM_DIR environment variable.
     """
+    if arasimsrc is None:
+        arasimsrc = os.getenv("ARA_SIM_DIR", None)
+
+    if not arasimsrc:
+        raise RuntimeError(
+            "ARA_SIM_DIR environment variable not set. "
+            "Please set it to the AraSim source directory."
+        )
+
+    arasimsrc = os.path.abspath(arasimsrc)
+
+    # Load the AraSim ray-tracing headers into ROOT's interpreter so the
+    # corresponding C++ classes can be used from Python.
+
     ROOT.gInterpreter.ProcessLine(f'#include "{arasimsrc}/RayTrace.h"')
     ROOT.gInterpreter.ProcessLine(f'#include "{arasimsrc}/RayTrace_IceModels.h"')
     ROOT.gInterpreter.ProcessLine(f'#include "{arasimsrc}/Vector.h"')
     ROOT.gInterpreter.ProcessLine('#include <vector>')
+
+    # Instantiate the attenuation model and the exponential refractive-index
+    # model used by the ray tracer. The refractive-index parameters are the
+    # same as those used in the PA analysis paper.
 
     ROOT.gInterpreter.ProcessLine(
         'auto _rt_atten = boost::shared_ptr<basicAttenuationModel>'
         '(new basicAttenuationModel);'
     )
     ROOT.gInterpreter.ProcessLine(
-        f'auto _rt_refr = boost::shared_ptr<exponentialRefractiveIndex>'
-        f'(new exponentialRefractiveIndex({1.3260},{1.780},{0.0202}));'
+        'auto _rt_refr = boost::shared_ptr<exponentialRefractiveIndex>'
+        '(new exponentialRefractiveIndex(1.3260,1.780,0.0202));'
     )
+
+    # Create the AraSim ray-tracing engine from the refractive-index and
+    # attenuation models above
+
     ROOT.gInterpreter.ProcessLine('RayTrace::TraceFinder _rt_tf(_rt_refr, _rt_atten);')
+
+    # Declare source/receiver vectors used by the ray-tracing machinery.
+
     ROOT.gInterpreter.ProcessLine('Vector _rt_src; Vector _rt_rec;')
 
+    # Declare helper C++ code inside ROOT.
+    #
+    # This block:
+    #  1. defines persistent vectors to store the traced ray path
+    #     (x, z, and RK step type),
+    #  2. defines a callback functor that is called at each tracing step
+    #     and saves the current ray position,
+    #  3. wraps the AraSim doTrace call in a helper function
+    #     (rt_doTrace_savePoints) that clears old path data, runs the trace,
+    #     and records all intermediate path points, and
+    #  4. exposes getter functions so Python can retrieve the saved path.
+    #
+    # We need this because for reconstruction-sphere mapping we do not only
+    # need the final ray-trace solution; we also need the intermediate traced
+    # path points to determine where the selected ray branch crosses the sphere.
     ROOT.gInterpreter.Declare(r'''
         #include <vector>
 
+        // Traced x positions along the ray path.
         static std::vector<double> _rt_x;
-        static std::vector<double> _rt_z;
-        static std::vector<int>    _rt_stepType;
 
+        // Traced z positions along the ray path.
+        static std::vector<double> _rt_z;
+
+        // RK step classification saved at each traced point.
+        static std::vector<int> _rt_stepType;
+
+        // Callback invoked at each ray-tracing step to save the current
+        // ray position and step type.
         struct RTPointSaver {
             void operator()(const RayTrace::fullRayPosition& p, RayTrace::RKStepType t) const {
                 _rt_x.push_back(p.x);
@@ -84,6 +133,9 @@ def load_raytrace_model(
             }
         };
 
+        // Wrapper around AraSim doTrace that clears any previously saved
+        // path information, runs the trace, and records all intermediate
+        // path points through the callback above.
         RayTrace::TraceRecord rt_doTrace_savePoints(
             double src_depth,
             double launch_theta,
@@ -105,42 +157,44 @@ def load_raytrace_model(
             );
         }
 
+        // Accessors used from Python to retrieve the saved traced path.
         const std::vector<double>& rt_get_x(){ return _rt_x; }
         const std::vector<double>& rt_get_z(){ return _rt_z; }
-        const std::vector<int>&    rt_get_stepType(){ return _rt_stepType; }
+        const std::vector<int>& rt_get_stepType(){ return _rt_stepType; }
     ''')
 
+    # Confirm that the helper function was successfully declared in ROOT.
     if not hasattr(ROOT, "rt_doTrace_savePoints"):
         raise RuntimeError("Failed to declare rt_doTrace_savePoints in ROOT.")
 
+#Load Model 
 
 load_raytrace_model()
 
 
 class AraGeom:
-
     """
     A class to initialize ARA geometry and provide associated utility functions.
     """
 
+
     def __init__(self, station_id):
         """
         Initialize the geometry tool and station information.
-
-        Parameters
-        ----------
-        station_id : int
-            ARA station number (e.g. 1, 2, 3, 4, 5).
         """
-        self.FEET_TO_METER = 0.3048
-        self.SUR_TO_GLOB   = np.array([22400, 53900, -36.02])
+        # Constants
+        self.FEET_TO_METER = 0.3048  # Conversion factor from feet to meter
+        self.SUR_TO_GLOB = np.array([22400, 53900, -36.02])  # Survey to global offset in feet
 
         self.station_id = station_id
-        self.geomTool   = ROOT.AraGeomTool.Instance()
-        self.st_info    = self.geomTool.getStationInfo(self.station_id)
+        # Initialize the Geometry Tool
+        self.geomTool = ROOT.AraGeomTool.Instance()
+
+        # Station information
+        self.st_info = self.geomTool.getStationInfo(self.station_id)
+
 
     def get_station_center(self, excluded_channels=None):
-        
         """
         Calculates the average x, y, and z coordinates of antennas for a given station.
 
@@ -155,22 +209,24 @@ class AraGeom:
            station center (x, y, z) for given station
         """
 
-
         if excluded_channels is None:
             excluded_channels = []
 
-        antenna_coordinates = [[] for _ in range(3)]
-        for antenna_index in range(constants.num_rf_channels):
+        antenna_coordinates = [[] for _ in range(3)]  # x, y, z
+        total_antennas = constants.num_rf_channels
+
+        for antenna_index in range(total_antennas):
             if antenna_index in excluded_channels:
                 continue
+
             antenna_info = self.st_info.getAntennaInfo(antenna_index)
             for axis in range(3):
                 antenna_coordinates[axis].append(antenna_info.antLocation[axis])
+        av_ant_position = tuple(np.average(coords) for coords in antenna_coordinates)
+        return av_ant_position
 
-        return tuple(np.average(coords) for coords in antenna_coordinates)
 
     def get_local_CP(self, list_of_cal_pulser_indices):
-
         """
         Parameters
         ----------
@@ -188,6 +244,7 @@ class AraGeom:
             cal_pulser_info = self.st_info.getCalAntennaInfo(int(cal_index))
             calpulsers[f'{cal_index}'] = [cal_pulser_info.antLocation[i] for i in range(3)]
         return calpulsers
+
 
     def get_survey_to_global_coords(self, easting, northing, elevation=None):
         """
@@ -210,8 +267,8 @@ class AraGeom:
         if elevation is not None:
             return np.asarray([easting, northing, elevation]) - self.SUR_TO_GLOB
         return np.asarray([easting, northing]) - self.SUR_TO_GLOB[:2]
-
-    def get_array_from_lat_long(self, latitude, longitude):
+    
+    def get_array_from_lat_long(self,latitude,longitude):
         """
         Convert latitude/longitude to ARA array coordinates.
 
@@ -228,12 +285,13 @@ class AraGeom:
             Array coordinates [northing, easting, 0], in meters.
         """
 
-        easting  = self.geomTool.getEastingFromLatLong(latitude, longitude)
-        northing = self.geomTool.getNorthingFromLatLong(latitude, longitude)
-        return np.array([northing, easting, 0])
+        easting = self.geomTool.getEastingFromLatLong(latitude,longitude)
+        northing = self.geomTool.getNorthingFromLatLong(latitude,longitude)
+        return np.array([northing, easting,0])
+
+
 
     def get_global_to_station_centric(self, array_coords):
-
         """
         Convert global coordinates to station-centric coordinates.
 
@@ -245,13 +303,14 @@ class AraGeom:
         Returns
         -------
         - output_coords: numpy array
-          Station-centric coordinates [x', y', z'] in meters.
+          Station-centric coordinates [x', y', z'].
         """
 
-        input_coords  = np.array(array_coords, dtype=np.float64)
+        input_coords = np.array(array_coords, dtype=np.float64)
         output_coords = np.zeros(3, dtype=np.float64)
         self.geomTool.convertArrayToStationCoords(self.station_id, input_coords, output_coords)
         return output_coords
+
 
     def get_southpole_landmarks(self, landmark_type):
         """
@@ -261,7 +320,7 @@ class AraGeom:
         landmark_type : str
            ICL : stands for IceCube Lab
            WT : Wind Turbine
-           SPT : South Pole Telescope
+           SPT : South Pole Telescope (removed from landmark list due to depth bug in AraRoot)
 
         Returns
         -------
@@ -269,24 +328,25 @@ class AraGeom:
             The landmark location in ARA Gloabal (Array) Coordinate system
         """
 
-
         landmarks = []
         if landmark_type == "ICL":
             for i in range(1):  ## This can go range(4)
-                corner = self.geomTool.getICLCorner(i)  
+                corner = self.geomTool.getICLCorner(i)
                 landmarks.append([corner[0], corner[1], corner[2]])
-        elif landmark_type == "WT": ## This can go range(1,4)
+        elif landmark_type == "WT":  ## This can go range(1,4)
             for i in range(3, 4):
                 corner = self.geomTool.getWindTurbine(i)
                 landmarks.append([corner[0], corner[1], corner[2]])
         elif landmark_type == "SPRESSO":
             landmarks.append(self.get_array_from_lat_long(-89.93120, 144.51249))
-        elif landmark_type == "SPT":
-            corner = self.geomTool.getSouthPoleTelescope()
-            landmarks.append([corner[0], corner[1], corner[2]])
+        #elif landmark_type == "SPT":
+        #    corner = self.geomTool.getSouthPoleTelescope()
+        #    landmarks.append([corner[0], corner[1], corner[2]])
         else:
             raise ValueError(f"Unknown landmark type: {landmark_type}")
         return landmarks
+
+
 
     def get_distant_pulsers(self, pulser_name, spice_depth=None):
         """
@@ -306,28 +366,25 @@ class AraGeom:
           X, Y, Z location of pulser in station centric
         """
 
-
         if pulser_name == "SPIce" and spice_depth is None:
             raise ValueError(f"Unknown SPIce pulser depth")
-
         pulser_coords = {
-            "IC1S":  [45659.6457, 50490.4199],
+            "IC1S": [45659.6457, 50490.4199],
             "IC22S": [44884.416, 51444.8819],
             "SPIce": [42600, 48800],
         }
         pulser_depths = {"IC1S": -1400, "IC22S": -1450.47, "SPIce": spice_depth}
-
         if pulser_name not in pulser_coords:
             raise ValueError(f"Unknown pulser name: {pulser_name}")
 
         easting, northing = pulser_coords[pulser_name]
         global_coords = self.get_survey_to_global_coords(easting, northing) * self.FEET_TO_METER
         global_coords = [float(global_coords[0]), float(global_coords[1]), 0]
-        st_centric    = self.get_global_to_station_centric(global_coords)
-        return st_centric[0], st_centric[1], pulser_depths[pulser_name]
+        st_centric_coords = self.get_global_to_station_centric(global_coords)
+        return st_centric_coords[0], st_centric_coords[1], pulser_depths[pulser_name]
+
 
     def get_relative_cartesian_to_spherical(self, reference_point, target_point):
-
         """
         Compute the spherical coordinates of a vector defined by two Cartesian points.
 
@@ -352,13 +409,14 @@ class AraGeom:
             The azimuth angle (phi) in degrees, measured from the x-axis in the xy-plane.
         """
 
-
-        delta    = np.array(target_point) - np.array(reference_point)
-        x, y, z  = delta
-        r        = np.sqrt(x**2 + y**2 + z**2)
-        theta    = np.degrees(np.arccos(z / r))
-        phi      = np.degrees(np.arctan2(y, x))
+        delta = np.array(target_point) - np.array(reference_point)
+        x, y, z = delta
+        r = np.sqrt(x**2 + y**2 + z**2)
+        theta = np.degrees(np.arccos(z / r))
+        phi = np.degrees(np.arctan2(y, x))
         return r, 90 - theta, phi
+
+
 
     def get_critical_angle(self):
         """
@@ -367,12 +425,191 @@ class AraGeom:
         critical angle in terms of elevation angle
 
         """
-        
-        station_depth  = self.get_station_center()[2]
-        n_air          = constants.get_index_of_refraction(1e-3)
-        n_ice          = constants.get_index_of_refraction(station_depth)
-        critical_angle = np.arcsin(n_air / n_ice)
-        return 90 - np.degrees(critical_angle)
+        station_depth = self.get_station_center()[2]
+        n_air = constants.get_index_of_refraction(1e-3)
+        n_ice = constants.get_index_of_refraction(station_depth)
+        critical_angle = np.arcsin(n_air/n_ice)
+        critical_angle *= (180/np.pi)
+
+        return 90 - critical_angle  ## In terms of elevation angle
+
+
+
+
+    def _circle_intersect(self, p0, v, radius, t_max=1.0):
+        """
+        Find the first intersection of a straight line segment (or ray) with the
+        station-centered circle x^2 + z^2 = radius^2 in the local propagation plane.
+
+        Here, p(t) = p0 + t*v parameterizes only the local straight segment used for
+        interpolation between two successive sampled ray-trace points. It does NOT
+        represent the full curved ray-trace path. The full path comes from AraSim;
+        this helper is used only to determine where that discretely sampled path
+        crosses the reconstruction circle more accurately than choosing the sampled
+        point whose radius is merely closest to R_sphere.
+
+        In the local propagation plane:
+          - x >= 0 : radial distance from the station, in meters
+          - z      : vertical offset from the station, in meters (positive upward)
+
+        Substituting p(t) into x^2 + z^2 = radius^2 gives:
+          a*t^2 + b*t + c = 0
+        with
+          a = |v|^2
+          b = 2 * dot(p0, v)
+          c = |p0|^2 - radius^2
+
+        The two roots are checked in increasing order so the nearest valid crossing
+        is returned first. Only roots with 0 <= t <= t_max are accepted.
+
+        Parameters
+        ----------
+        p0 : tuple of float
+            Start point (x, z), in meters.
+        v : tuple of float
+            Direction vector (vx, vz) in the local (x, z) plane. For a finite
+            segment, pass p1 - p0.
+        radius : float
+            Circle radius, in meters (= R_sphere or R_map).
+        t_max : float, optional
+            Upper bound on t. In this file, t_max = 1.0 is used for a finite
+            segment between successive sampled points.
+
+        Returns
+        -------
+        tuple or None
+            (x, z, t) for the first valid intersection, with x and z in meters,
+            or None if no valid intersection exists.
+        """
+        x0, z0 = p0
+        vx, vz = v
+
+        a = vx * vx + vz * vz
+        if a == 0.0:
+            return None  # zero-length segment / direction vector
+
+        b = 2.0 * (x0 * vx + z0 * vz)
+        c = x0 * x0 + z0 * z0 - radius * radius
+        disc = b * b - 4.0 * a * c
+        if disc < 0.0:
+            return None  # no real intersection with the circle
+
+        sq = np.sqrt(disc)
+        for t in ((-b - sq) / (2.0 * a), (-b + sq) / (2.0 * a)):
+            if 0.0 <= t <= t_max:
+                x = x0 + t * vx
+                z = z0 + t * vz
+                if x >= 0.0:  # radial distance from station must be non-negative
+                    return (x, z, t)
+
+        return None
+
+
+    def _find_sphere_crossing_from_samples(
+        self,
+        xs,
+        zs,
+        z_ref,
+        radius,
+        reverse_search=False,
+    ):
+        """
+        Find the intersection of sampled ray-trace points with the station-centered
+        circle x^2 + z^2 = radius^2 in the local propagation plane.
+
+        This helper is shared by:
+          - get_raytraced_sphere_crossing_angles()
+          - get_raytraced_critical_angle()
+
+        It finds the first pair of consecutive sampled points that bracket the desired radius and
+        then interpolates the crossing on that finite segment using
+        self._circle_intersect().
+
+        Parameters
+        ----------
+        xs : array-like
+            Sampled horizontal coordinates in the local propagation plane, in meters.
+        zs : array-like
+            Sampled vertical coordinates in the local propagation plane, in meters.
+        z_ref : float
+            Reference station depth, in meters, used to convert z samples into
+            station-centered vertical offsets dz = z - z_ref.
+        radius : float
+            Target circle / sphere radius, in meters.
+        reverse_search : bool, optional
+            If True, search from the end of the sampled path backward. This is used
+            for source->station traces, where the desired crossing is the outermost
+            one encountered before arriving at the station (for finding crossing point with the radius map for source
+            within the radius map. 
+
+            Example:
+                For a source outside the map radius (e.g., r = 1000 m) and
+                R_sphere = 300 m, the sampled distances along the ray may look like:
+                    1000 → 800 → 500 → 350 → 280 → 100 → 0 (station)
+                The crossing of R_sphere occurs between 350 → 280.
+                We search backward to select this crossing before reaching
+                the station.
+
+            If False, search from the beginning forward. This is used for
+            station->outward traces (for finding ray-traced critical angle)
+            Example:
+                For an outward trace starting at the station (r = 40m) with
+                R_sphere = 300 m, the sampled distances may look like:
+                    40 → 100 → 150 → 280 → 350 → 500
+                The crossing of R_sphere occurs between 280 → 350.
+                We search forward to select this first crossing after leaving
+                the station.
+
+        Returns
+        -------
+        tuple
+            (inter, i_cross), where:
+              - inter is (x_cross, z_cross, t) from self._circle_intersect(), or None
+              - i_cross is the bracketing segment index, or None if no crossing exists
+        """
+        xp = np.asarray(xs, dtype=float)
+        dz = np.asarray(zs, dtype=float) - float(z_ref)
+
+        if len(xp) < 2:
+            return None, None
+
+        d = np.hypot(xp, dz)
+
+        if reverse_search:
+            # Samples run from source toward station: outside -> inside.
+            # We want the last crossing before reaching the station.
+            i_cross = next(
+                (i for i in range(len(d) - 1, 0, -1) if d[i] <= radius < d[i - 1]),
+                None,
+            )
+            if i_cross is None:
+                return None, None
+
+            p0 = (float(xp[i_cross - 1]), float(dz[i_cross - 1]))  # outside
+            p1 = (float(xp[i_cross]),     float(dz[i_cross]))      # inside
+
+        else:
+            # Samples run outward from the station: inside -> outside.
+            # We want the first crossing after leaving the station.
+            i_cross = next(
+                (i for i in range(1, len(d)) if d[i - 1] <= radius < d[i]),
+                None,
+            )
+            if i_cross is None:
+                return None, None
+
+            p0 = (float(xp[i_cross - 1]), float(dz[i_cross - 1]))  # inside
+            p1 = (float(xp[i_cross]),     float(dz[i_cross]))      # outside
+
+        inter = self._circle_intersect(
+            p0,
+            (p1[0] - p0[0], p1[1] - p0[1]),
+            float(radius),
+            t_max=1.0,
+        )
+
+        return inter, i_cross
+
 
     def get_raytraced_sphere_crossing_angles(
         self,
@@ -388,155 +625,102 @@ class AraGeom:
         Find the apparent direction of a source on a reconstruction sphere via ray tracing.
 
         The source is ray traced to the station center using AraSim's TraceFinder.
-        The selected ray branch is then intersected with a sphere of radius R_sphere(depending on --map_type)
-        centered on the station. This sphere crossing defines the apparent direction
-        (elevation, azimuth) that should be overlaid on the sky map.
+        The selected ray branch is intersected with the reconstruction sphere of
+        radius R_sphere centered on the station. That sphere crossing defines the
+        apparent direction (elevation, azimuth) that should be overlaid on the sky map.
 
-        If the traced path does not itself cross R_sphere (e.g. source is closer than
-        R_sphere, or the path curves away), the outermost traced point and its local
-        direction are used to extend the ray outward until it intersects the sphere
-        (backward extension). If the result is still unphysical (elevation outside
-        [-90, 90]), the straight-line direction is returned as a fallback.
+        If the source->station traced samples do not themselves cross R_sphere
+        (for example because the source lies inside R_sphere, or because the sampled
+        branch reaches the station before crossing the sphere), the same branch is
+        re-traced outward from the station using the branch receiptAngle. The sphere
+        crossing is then determined from those outward ray-traced samples.
 
-        Ray solutions are identified by propagation-time ordering:
-          - Shortest TOF  → label 'D' (direct)
-          - Second TOF    → label 'R' (surface-reflected / refracted)
+        If the mapped elevation lies outside the physical plotting range [-90, +90]
+        degrees, the straight-line (SL) direction is used only as a plotting fallback
+        and is flagged accordingly.
+
+        Ray solutions are identified only by propagation-time ordering:
+          - shortest TOF  -> label 'D' (direct)
+          - second TOF    -> label 'R' (reflected / refracted)
 
         Parameters
         ----------
         source_xyz : array-like
-            Source position [x, y, z] in station-centric Cartesian coordinates, in meters.
+            Source position [x, y, z] in station-centric Cartesian coordinates,
+            in meters.
         R_sphere : float
-            Radius of the reconstruction sphere, in meters.
+            Reconstruction sphere radius, in meters. Must be positive.
         accuracy : float, optional
-            Ray-tracing convergence accuracy passed to AraSim findPaths. Default 0.001.
+            Convergence tolerance passed to AraSim findPaths (dimensionless).
+            Default is 0.001.
         solution : int, optional
             Requested solution type:
               - 0 : direct path (shortest propagation time)
-              - 1 : reflected/refracted path (second-shortest propagation time)
-            If solution=1 and findPaths returns only 1 solution, returns [] immediately
-            so the caller can fall back to the straight-line direction.
+              - 1 : reflected / refracted path (second-shortest propagation time)
         frequency : float, optional
-            Signal frequency passed to AraSim ray tracer, in GHz. Default 0.5 GHz.
+            Signal frequency passed to the AraSim ray tracer, in GHz.
+            Default is 0.5 GHz.
         polarization : float, optional
-            Signal polarization passed to AraSim ray tracer, in radians. Default 0.0.
+            Signal polarization passed to the AraSim ray tracer, in radians.
+            Default is 0.0.
         station_center : array-like or None, optional
-            Station center [x, y, z] in station-centric Cartesian coordinates, in meters.
-            
+            Station center [x, y, z] in station-centric Cartesian coordinates,
+            in meters. If None, the internally stored station center is used.
 
         Returns
         -------
         list of dict
-            Empty list if ray tracing fails or no valid sphere crossing is found.
-            Otherwise a single-element list with keys:
-              - 'label'       : str, 'D' or 'R'
-              - 'elevation'   : float, elevation angle on R_sphere in degrees [-90, +90]
-              - 'azimuth'     : float, azimuth angle in degrees [-180, +180]
-              - 'tof'         : float, propagation time in nanoseconds
-              - 'path_len'    : float, path length in meters
-              - 'allowedUsed' : int, AraSim reflection mode flag
+            Each dict corresponds to one valid ray-traced solution and contains:
+              - 'label'            : 'D' or 'R'
+              - 'elevation'        : elevation angle on R_sphere, in degrees
+              - 'azimuth'          : azimuth angle, in degrees
+              - 'tof'              : propagation time, in nanoseconds
+              - 'path_len'         : ray path length, in meters
+              - 'allowedUsed'      : AraSim reflection-mode flag
+              - 'used_sl_fallback' : bool, True only if plotting fell back to SL
         """
+        if R_sphere is None:
+            raise ValueError("R_sphere must be provided to get_raytraced_sphere_crossing_angles().")
+        if R_sphere <= 0:
+            raise ValueError(f"R_sphere must be positive, got {R_sphere}.")
 
         src = np.asarray(source_xyz, dtype=float)
-        rec = np.asarray(station_center if station_center is not None else self.get_station_center(), dtype=float)
-        R = float(R_sphere) # radius of the map
+        rec = np.asarray(
+            station_center if station_center is not None else self.get_station_center(),
+            dtype=float,
+        )
+        R = float(R_sphere)
 
-        z_src  = float(src[2])
-        z_rec  = float(rec[2])
+        z_src = float(src[2])
+        z_rec = float(rec[2])
 
-        dx     = float(src[0] - rec[0])
-        dy     = float(src[1] - rec[1])
-        r_src  = float(np.hypot(dx, dy))
+        dx = float(src[0] - rec[0])
+        dy = float(src[1] - rec[1])
+        r_src = float(np.hypot(dx, dy))
         az_phi = float(np.arctan2(dy, dx))
 
-        
         ROOT._rt_src.SetXYZ(r_src, 0.0, z_src)
-        ROOT._rt_rec.SetXYZ(0.0,   0.0, z_rec)
+        ROOT._rt_rec.SetXYZ(0.0, 0.0, z_rec)
 
-        def _circle_intersect(p0, v, radius, t_max=np.inf):
-
-            """
-            Find the first intersection of p(t) = p0 + t*v with the
-            station-centered circle x^2 + z^2 = radius^2 in the local
-            propagation plane, where:
-              - x >= 0 : radial distance from station, in meters
-              - z      : vertical offset from station, in meters (positive upward)
-
-            Parameterizes the path as p(t) = p0 + t*v and substitutes into
-            the circle equation to get the quadratic a*t^2 + b*t + c = 0:
-              a = |v|^2
-              b = 2 * dot(p0, v)
-              c = |p0|^2 - radius^2
-            
-            The quadratic has two roots t1 (smaller) and t2 (larger).
-            t1 is the entry point into the circle, t2 is the exit point.
-            We iterate smallest-first so we always return the nearest valid crossing.
-            The two roots t1, t2 are the candidate intersections. Only roots
-            with 0 <= t <= t_max  (lies on the segment (t_max=1) or forward ray (t_max=inf))
-            and 
-            x >= 0 are physically valid. (physically valid radial coordinate (radius cannot be negative))
-
-            Used in two modes:
-              - Segment (forward crossing):  t_max=1.0, v = p1 - p0
-              - Ray (backward extension):    t_max=inf, v = local direction at p_far
-
-            Parameters
-            ----------
-            p0 : tuple
-                Start point (x, z) in meters.
-            v : tuple
-                Direction vector (vx, vz) in meters. For a segment, pass p1-p0.
-            radius : float
-                Circle radius in meters (= R_sphere).
-            t_max : float, optional
-                Upper bound on t. Default inf (semi-infinite ray).
-
-            Returns
-            -------
-            tuple or None
-                (x, z, t) of the first valid intersection in meters, or None.
-            """
-            
-            x0, z0 = p0  # start point components
-            vx, vz = v  # direction vector components
-            a = vx*vx + vz*vz  # quadratic coefficient: |v|^2
-            if a == 0.0:
-                return None                         # zero-length direction vector, no intersection possible
-            b    = 2.0*(x0*vx + z0*vz)              # quadratic coefficient: 2*dot(p0, v)
-            c    = x0*x0 + z0*z0 - radius*radius    # quadratic coefficient: |p0|^2 - R^2
-            disc = b*b - 4.0*a*c                    # discriminant: negative means no real intersection
-            if disc < 0.0:
-                return None                                 # ray misses the circle entirely
-            sq = np.sqrt(disc)                               # square root of discriminant
-            for t in ((-b - sq)/(2.0*a), (-b + sq)/(2.0*a)):   # t1 (near), t2 (far) roots, smallest first
-                if 0.0 <= t <= t_max:                 # t must lie on segment (t_max=1) or forward ray (t_max=inf)
-                    x, z = x0 + t*vx, z0 + t*vz       # intersection point
-                    if x >= 0.0:                      # x >= 0 required: radial distance cannot be negative
-                        return (x, z, t)              # return first valid crossing
-            return None
-
-        """
-        findPaths from source to station: AraSim searches for all ray solutions in its 2D cylindrical propagation plane (x = horizontal radial distance
-        from source, z = depth). Returns up to 2 solutions ordered by TOF:
-          sol[0] -> direct path (D)   : shortest propagation time, travels directly
-                                         through ice from source to station
-          sol[1] -> reflected path (R): second-shortest, reflects off the ice surface
-                                         before reaching the station
-        """
-
+        # findPaths searches in AraSim's 2D cylindrical propagation plane and
+        # returns the available ray solutions. We later label them only by TOF:
+        # shortest -> D, second-shortest -> R.
         sol_cnt = ctypes.c_int()
         sol_err = ctypes.c_int()
-        paths   = ROOT._rt_tf.findPaths(
-            ROOT._rt_src, ROOT._rt_rec,
-            float(frequency), ROOT.TMath.Pi() / 2,
-            sol_cnt, sol_err,
-            int(ROOT.RayTrace.SurfaceReflection), float(accuracy),
+        paths = ROOT._rt_tf.findPaths(
+            ROOT._rt_src,
+            ROOT._rt_rec,
+            float(frequency),
+            ROOT.TMath.Pi() / 2,
+            sol_cnt,
+            sol_err,
+            int(ROOT.RayTrace.SurfaceReflection),
+            float(accuracy),
         )
 
-        self._last_rt_npaths      = 0
-        self._last_rt_paths       = []
+        self._last_rt_npaths = 0
+        self._last_rt_paths = []
         self._last_rt_fail_reason = None
-
 
         if sol_err.value != 0 or not paths or len(paths) == 0:
             self._last_rt_fail_reason = (
@@ -546,194 +730,334 @@ class AraGeom:
             )
             return []
 
-
         sorted_paths = sorted(paths, key=lambda p: float(p.pathTime))
 
         self._last_rt_npaths = len(sorted_paths)
-        self._last_rt_paths  = [
-            {"tof": float(p.pathTime)*1e9, "path_len": float(p.pathLen),
-             "launchAngle": float(p.launchAngle)}
+        self._last_rt_paths = [
+            {
+                "tof": float(p.pathTime) * 1e9,
+                "path_len": float(p.pathLen),
+                "launchAngle": float(p.launchAngle),
+            }
             for p in sorted_paths
         ]
 
-
-
-        # Label by TOF: shortest=D, second=R
         labeled = []
-        if len(sorted_paths) >= 1: labeled.append((sorted_paths[0], "D"))
-        if len(sorted_paths) >= 2: labeled.append((sorted_paths[1], "R"))
+        if len(sorted_paths) >= 1:
+            labeled.append((sorted_paths[0], "D"))
+        if len(sorted_paths) >= 2:
+            labeled.append((sorted_paths[1], "R"))
 
         if solution == 0:
             to_trace = [(p, l) for p, l in labeled if l == "D"]
         elif solution == 1:
             to_trace = [(p, l) for p, l in labeled if l == "R"]
             if not to_trace:
-                # Only 1 solution from ray tracer — R simply does not exist
-                #print(" [INFO] R solution not found: findPaths returned only 1 solution")
                 self._last_rt_fail_reason = "R solution not found: only 1 ray-trace solution exists"
                 return []
-  
+        else:
+            raise ValueError(f"solution must be 0 or 1, got {solution}.")
 
         allowed_used = int(ROOT.RayTrace.SurfaceReflection)
 
-        # Straight-line fallback (used only if RT elevation is unphysical)
-
+        # Straight-line direction is used only as a last-resort plotting fallback
+        # if the mapped RT elevation lies outside [-90, +90] degrees.
         _, elev_sl, az_sl = self.get_relative_cartesian_to_spherical(rec, src)
 
         out = []
         for path, label in to_trace:
+            used_sl_fallback = False
+
+            # First trace: source -> station along the chosen TOF-ordered branch.
             sol_error = ctypes.c_int(0)
             ROOT.rt_doTrace_savePoints(
-                z_src, float(path.launchAngle),
+                z_src,
+                float(path.launchAngle),
                 ROOT.RayTrace.rayTargetRecord(z_rec, r_src),
-                allowed_used, float(frequency), float(polarization), sol_error,
+                allowed_used,
+                float(frequency),
+                float(polarization),
+                sol_error,
             )
 
             xs = np.asarray(list(ROOT.rt_get_x()), dtype=float)
             zs = np.asarray(list(ROOT.rt_get_z()), dtype=float)
 
             if sol_error.value != 0 or len(xs) < 2:
-                print(f" [TRACE FAIL] label={label}  sol_error={sol_error.value}  npts={len(xs)}")
+                print(f"[TRACE FAIL] label={label}  sol_error={sol_error.value}  npts={len(xs)}")
                 continue
 
-            # Receiver-centered coordinates in the local propagation plane
-            xp       = r_src - xs       # radial distance from station, meters
-            dz       = zs - z_rec       # vertical offset from station, meters
-            d_to_rec = np.hypot(xp, dz) # distance from station along path, meters
+            # Convert source->station samples into receiver-centered coordinates.
+            # xp_forward is radial distance from station in meters.
+            xp_forward = r_src - xs
 
-            # Forward crossing: find where path crosses R_sphere outward from station
-            # i_cross is the index where d steps from outside (d>=R) to inside (d<R)
-            i_cross = next(
-                (i for i in range(len(d_to_rec)-1, 0, -1)
-                 if d_to_rec[i] <= R < d_to_rec[i-1]),
-                None
+            # For source->station samples, search from the end backward because
+            # the path terminates at the station and we want the outer sphere crossing.
+            inter, i_cross = self._find_sphere_crossing_from_samples(
+                xp_forward,
+                zs,
+                z_rec,
+                R,
+                reverse_search=True,
             )
 
-            if i_cross is not None:
-                p_out = (float(xp[i_cross-1]), float(dz[i_cross-1])) # point just outside R_sphere
-                p_in  = (float(xp[i_cross]),   float(dz[i_cross]))   # point just inside R_sphere
-                inter = _circle_intersect( 
-                    p_out, (p_in[0]-p_out[0], p_in[1]-p_out[1]), R, t_max=1.0)   # interpolate exact crossing on segment
-                
-            else:
-                
-                # Path never reaches R_sphere — source is inside R_sphere or path curves away.
-                # Extend the ray from the outermost traced point using its local direction.
-                imax          = int(np.argmax(d_to_rec))    # index of point farthest from station
-                i_far, i_near = (0, 1) if imax == 0 else (imax, imax-1)     # far point and its neighbor for direction
-                p_far         = (float(xp[i_far]),  float(dz[i_far]))       # outermost traced point
-                p_near        = (float(xp[i_near]), float(dz[i_near]))      # neighbor point, defines local ray direction
-                v_ext         = (p_far[0]-p_near[0], p_far[1]-p_near[1])    # local direction vector at p_far
-                inter         = _circle_intersect(p_far, v_ext, R)        # extend ray until it hits R_sphere
-
             if inter is None:
-                # Neither forward crossing nor backward extension reached R_sphere
-                self._last_rt_fail_reason = (
-                    f"no valid crossing/extension to R_sphere={R:.3f} m survived")
-                continue
+                print(
+                    f"[BACKTRACE INFO] label={label}  "
+                    f"n_ray_solutions={self._last_rt_npaths}  "
+                    f"forward_trace_found_no_crossing=True  "
+                    f"R_sphere={R:.3f} m  "
+                    f"source_r={r_src:.3f} m  "
+                    f"source_z={z_src:.3f} m"
+                )
 
-            xp_c, dz_c, _ = inter   # unpack crossing coordinates, discard t
-            elev = np.degrees(np.arctan2(dz_c, xp_c)) # elevation angle at sphere crossing, degrees
-            az   = np.degrees(az_phi)                       # azimuth angle
+                if not hasattr(path, "receiptAngle"):
+                    self._last_rt_fail_reason = (
+                        f"ray-traced solution exists for label={label}, but no forward crossing "
+                        f"was found for R_sphere={R:.3f} m and receiptAngle is unavailable "
+                        f"for backward tracing"
+                    )
+                    print(f"[BACKTRACE FAIL] {self._last_rt_fail_reason}")
+                    continue
+
+                # Re-trace the same branch outward from the station using AraSim,
+                
+                sol_error_back = ctypes.c_int(0)
+                r_back_target = max(float(R) + 50.0, float(r_src) + 50.0)
+
+                ROOT.rt_doTrace_savePoints(
+                    z_rec,
+                    float(path.receiptAngle),
+                    ROOT.RayTrace.rayTargetRecord(float(z_src), r_back_target),
+                    allowed_used,
+                    float(frequency),
+                    float(polarization),
+                    sol_error_back,
+                )
+
+                xs_back = np.asarray(list(ROOT.rt_get_x()), dtype=float)
+                zs_back = np.asarray(list(ROOT.rt_get_z()), dtype=float)
+
+                if sol_error_back.value != 0 or len(xs_back) < 2:
+                    self._last_rt_fail_reason = (
+                        f"backward trace failed for label={label}: "
+                        f"sol_error={sol_error_back.value}, npts={len(xs_back)}"
+                    )
+                    print(f"[BACKTRACE FAIL] {self._last_rt_fail_reason}")
+                    continue
+
+                inter, i_cross_back = self._find_sphere_crossing_from_samples(
+                    xs_back,
+                    zs_back,
+                    z_rec,
+                    R,
+                    reverse_search=False,
+                )
+
+                if inter is not None:
+                    print(
+                        f"[BACKTRACE OK] label={label}  "
+                        f"R_sphere={R:.3f} m  "
+                        f"crossing_index={i_cross_back}  "
+                        f"npts={len(xs_back)}"
+                    )
+                else:
+                    self._last_rt_fail_reason = (
+                        f"ray-traced solution found for label={label} "
+                        f"(n_ray_solutions={self._last_rt_npaths}), but neither forward "
+                        f"nor backward traced samples crossed R_sphere={R:.3f} m"
+                    )
+                    print(f"[BACKTRACE FAIL] {self._last_rt_fail_reason}")
+                    continue
+
+            xp_c, dz_c, _ = inter
+            elev = float(np.degrees(np.arctan2(dz_c, xp_c)))
+            az = float(np.degrees(az_phi))
 
             if not (-90.0 <= elev <= 90.0):
-                elev, az = elev_sl, az_sl   # unphysical elevation — fall back to straight-line
+                self._last_rt_fail_reason = (
+                    f"ray-traced elevation {elev:.3f} deg outside [-90, 90]; "
+                    f"used straight-line fallback for plotting"
+                )
+                elev, az = elev_sl, az_sl
+                used_sl_fallback = True
 
-            out.append({
-                "label"      : label,
-                "elevation"  : float(elev),
-                "azimuth"    : float(az),
-                "tof"        : float(path.pathTime) * 1e9,
-                "path_len"   : float(path.pathLen),
-                "allowedUsed": allowed_used,
-            })
+            out.append(
+                {
+                    "label": label,
+                    "elevation": float(elev),
+                    "azimuth": float(az),
+                    "tof": float(path.pathTime) * 1e9,
+                    "path_len": float(path.pathLen),
+                    "allowedUsed": allowed_used,
+                    "used_sl_fallback": used_sl_fallback,
+                }
+            )
 
-        if not out:
-            self._last_rt_fail_reason = (
-                f"no valid crossing/extension to R_sphere={R:.3f} m survived")
+        if not out and not self._last_rt_fail_reason:
+            self._last_rt_fail_reason = f"no valid crossing to R_sphere={R:.3f} m survived"
 
         return out
 
-    
-    def get_raytraced_critical_angle(self, R_sphere):
 
+
+    def get_raytraced_critical_angle(
+        self,
+        R_sphere,
+        frequency=0.5,
+        polarization=0.0,
+    ):
         """
-        Map the critical reception angle onto the reconstruction sphere via ray tracing.
+        Map the critical reception angle onto the reconstruction sphere using the
+        AraSim ray tracer.
 
-        Integrates the critical-angle ray upward from the station through the ice
-        using the Snell invariant n(z)*sin(theta) = n_air. The refractive index
-        n(z) is evaluated at each step via constants.get_index_of_refraction(z)
-        — no hardcoded ice model parameters.
+        The critical angle is first defined locally at the station via
+        get_critical_angle(), which returns the geometric critical elevation
+        in degrees. That local critical direction is then traced outward with
+        AraSim, and the apparent critical angle on the sky map is defined by
+        where that ray-traced trajectory crosses the reconstruction sphere of
+        radius R_sphere centered on the station.
 
-        Two successful exit conditions:
-          1. Ray crosses R_sphere within ice: returns the crossing elevation.
-          2. Ray exits ice (z=0) before reaching R_sphere: returns the elevation
-             of the surface-exit point. This occurs for large R_sphere (e.g. 300 m)
-             where the ray reaches the surface before the sphere boundary.
+        The initial launch direction is obtained from get_critical_angle(),
+        which computes the geometric critical angle at the station depth using
+        the local index of refraction. This provides a first-order estimate of
+        the direction from which a critically refracted ray would arrive at the
+        station in a straight-line (locally uniform medium) approximation.
 
-        Falls back to get_critical_angle() (geometric, no ray bending) if:
-          - sin(theta) >= 1 is encountered during integration, meaning the ray
-            cannot propagate upward from that depth.
-          - The sphere-crossing elevation is outside [-90, 90] degrees.
-          - The integration loop exits without finding any crossing.
+        This direction is then used to initialize the AraSim ray tracer at the
+        station depth. The full ray-traced trajectory accounts for the depth-
+        dependent refractive index profile n(z), allowing the curved ray path
+        corresponding to that critical condition to be followed through the ice.
+
+        The ray is launched from the station rather than from the surface. This
+        relies on ray-path reversibility: the outward-traced trajectory is the
+        time-reversed equivalent of a ray arriving at the station at the critical
+        angle. Using the station depth as the starting point ensures a well-defined
+        initial condition for the ray tracer and maintains consistency with how
+        other ray-traced directions are constructed in this module.
+
+        This function uses the same sampled sphere-crossing logic as
+        get_raytraced_sphere_crossing_angles():
+          1. Ray trace the trajectory outward from the station.
+          2. Search the traced (x, z) samples for a crossing of R_sphere.
+          3. Interpolate the crossing on the bracketing segment with
+             self._circle_intersect() via the shared helper
+             self._find_sphere_crossing_from_samples().
+
+        Unlike the source-mapping case, no source->station ray-tracing step is
+        required. The critical-angle trajectory is defined locally at the station,
+        so it can be traced directly outward from the station. Therefore only a
+        single outward ray trace is needed, and no fallback re-tracing is required.
+
+        The ray is traced continuously through the ice-air interface; reaching
+        z = 0 is not treated as a terminal condition. To ensure this, the outward
+        target is placed slightly above the surface.
+
+        Falls back to get_critical_angle() (geometric, no ray bending) only if
+        no valid ray-traced crossing on R_sphere can be determined, or if the
+        mapped ray-traced elevation is outside the physical plotting range
+        [-90, +90] degrees.
 
         Parameters
         ----------
         R_sphere : float
-            Reconstruction sphere radius, in meters.
+            Reconstruction sphere radius, in meters. Must be positive.
+        frequency : float, optional
+            Signal frequency passed to the AraSim ray tracer, in GHz.
+            Default is 0.5 GHz.
+        polarization : float, optional
+            Signal polarization passed to the AraSim ray tracer, in radians.
+            Default is 0.0.
 
         Returns
         -------
         float
-            Elevation angle in degrees where the critical-angle ray appears on
-            the reconstruction sphere. Range: [0, 90].
-            Returns get_critical_angle() on any failure.
+            Elevation angle, in degrees, where the ray-traced critical-angle
+            trajectory appears on the reconstruction sphere. Returns
+            get_critical_angle() only if no valid RT-based crossing can be obtained.
         """
+        if R_sphere is None:
+            raise ValueError("R_sphere must be provided to get_raytraced_critical_angle().")
+        if R_sphere <= 0:
+            raise ValueError(f"R_sphere must be positive, got {R_sphere}.")
 
-        z_rec  = float(self.get_station_center()[2])
+        z_rec = float(self.get_station_center()[2])
         R = float(R_sphere)
-        n_air  = constants.get_index_of_refraction(1e-3)
-        #n_ice  = constants.get_index_of_refraction(z_rec)
 
-        dz_step = 0.1  # integration step, meters 
-        z_prev, r_prev, d_prev = z_rec, 0.0, 0.0
+        # Geometric critical angle (straight line, no bending) approximation evaluated at the station depth using the local
+        # index of refraction that defines the direction from which a critically refracted ray would
+        # arrive at the station.
+        crit_elev_deg = float(self.get_critical_angle())
 
-        while z_prev < 0.0:
-            z_curr = z_prev + dz_step
-            n_z    = constants.get_index_of_refraction(z_prev + 0.5*dz_step)
-            sin_th = n_air / n_z
+        # Convert the local elevation to the angle convention required by the
+        # AraSim ray tracer. This direction is used as the initial launch angle
+        # at the station for the full ray-traced propagation in n(z).
+        crit_rt_angle = np.deg2rad(90.0 - crit_elev_deg)
 
-            if sin_th >= 1.0:
-                return float(self.get_critical_angle())
+        allowed_used = int(ROOT.RayTrace.SurfaceReflection)
 
-            r_curr  = r_prev + (sin_th / np.sqrt(1.0 - sin_th**2)) * dz_step
-            dz_curr = z_curr - z_rec
-            d_curr  = np.hypot(r_curr, dz_curr)
+        # Initialize the ray tracer at the station depth (z_rec). Although the
+        # critical angle is defined for a ray approaching the surface from below,
+        # we launch the ray outward from the station using the same direction.
+        # By ray-path reversibility, this outward trajectory is equivalent to
+        # the time-reversed incoming critical ray and therefore traces the same
+        # physical path through the medium.
+        #
+        # The target is placed slightly above the surface to ensure that the ray
+        # is allowed to continue through the ice-air interface rather than
+        # effectively stopping at z = 0.
+        r_target = float(R + 50.0)
+        z_target = 0.050  # in meters; slightly above the ice surface
 
- 
-            # Case 1: ray crosses R_sphere while still in ice
-            if d_prev <= R < d_curr:
-                frac     = (R - d_prev) / (d_curr - d_prev)          # fraction along step where d = R exactly
-                r_cross  = r_prev + frac*(r_curr - r_prev)            # horizontal radial distance at crossing, meters
-                dz_cross = (z_prev + frac*(z_curr - z_prev)) - z_rec  # vertical offset from station at crossing, meters
-                elev     = float(np.degrees(np.arctan2(dz_cross, r_cross)))  # elevation angle at crossing, degrees
-                if not (-90.0 <= elev <= 90.0):
-                    return float(self.get_critical_angle())
-                return elev
+        sol_error = ctypes.c_int(0)
+        ROOT.rt_doTrace_savePoints(
+            z_rec,
+            float(crit_rt_angle),
+            ROOT.RayTrace.rayTargetRecord(z_target, r_target),
+            allowed_used,
+            float(frequency),
+            float(polarization),
+            sol_error,
+        )
 
-            # Case 2: ray exits ice surface (z=0) before reaching R_sphere
-            if z_prev <= 0.0 <= z_curr:
-                frac   = (0.0 - z_prev) / (z_curr - z_prev)  # fraction along step where z = 0 exactly
-                r_surf = r_prev + frac*(r_curr - r_prev)      # horizontal radial distance at surface exit, meters
-                elev   = float(np.degrees(np.arctan2(-z_rec, r_surf)))  # elevation using station depth as vertical leg, degrees
-                if not (-90.0 <= elev <= 90.0):
-                    return float(self.get_critical_angle())
-                return elev
+        xs = np.asarray(list(ROOT.rt_get_x()), dtype=float)
+        zs = np.asarray(list(ROOT.rt_get_z()), dtype=float)
 
-            z_prev, r_prev, d_prev = z_curr, r_curr, d_curr
+        if sol_error.value != 0 or len(xs) < 2:
+            print(
+                f"[CRITICAL ANGLE RT FAIL] forward trace failed: "
+                f"sol_error={sol_error.value}, npts={len(xs)}"
+            )
+            return float(self.get_critical_angle())
 
-        return float(self.get_critical_angle()) # return the default critical angle if crossing case 1 and 2 fail
+        # Outward traces from the station are ordered station -> outward,
+        # so we search forward for the first inside->outside crossing.
+        inter, i_cross = self._find_sphere_crossing_from_samples(
+            xs,
+            zs,
+            z_rec,
+            R,
+            reverse_search=False,
+        )
 
+        if inter is None:
+            print(
+                f"[CRITICAL ANGLE RT FAIL] no valid RT crossing to "
+                f"R_sphere={R:.3f} m  critical_elevation={crit_elev_deg:.3f} deg"
+            )
+            return float(self.get_critical_angle())
+
+        x_cross, z_cross, _ = inter
+        elev = float(np.degrees(np.arctan2(z_cross, x_cross)))
+
+        if not (-90.0 <= elev <= 90.0):
+            print(
+                f"[CRITICAL ANGLE RT WARN] mapped elevation {elev:.3f} deg outside [-90, 90]; "
+                f"falling back to geometric critical angle with Straight Line approximation"
+            )
+            return float(self.get_critical_angle())
+
+        return elev
 
 
     def get_known_landmarks(
@@ -749,28 +1073,30 @@ class AraGeom:
 
         Each landmark is ray traced to the station and its direction is mapped onto
         the reconstruction sphere of radius R_map. The ray tracer (AraSim findPaths)
-        always returns at least 1 solution for all landmarks and all stations tested.
-        Solutions are ordered by propagation time (TOF):
-          - Shortest TOF  -> Direct path (D)  : travels straight through ice
-          - Second TOF    -> Reflected path (R): reflects off the ice surface
+        returns the available solutions, which are labeled only by propagation-time
+        ordering:
+          - shortest TOF  -> Direct path (D)
+          - second TOF    -> Reflected / refracted path (R)
 
-        Which solution is shown on the map depends on the map type:
-          - direct maps   (e.g. pulser_*, distant_*_dir) : solution=0, shows D
-          - reflected maps (e.g. distant_*_ref)           : solution=1, shows R
+        Which solution is shown depends on the requested map / solution choice:
+          - direct maps      : solution = 0, show D
+          - reflected maps   : solution = 1, show R
 
         Fallback rules:
-          - D solution: shown on map unless the traced path never crosses R_map.
-            This can happen if the source is closer to the station than R_map
-            AND the backward extension of the path also fails to reach R_map
-            (e.g. source inside R_map with a nearly vertical path). Falls back
-            to straight-line (SL) direction in that case.
+          - D solution: shown unless the ray-traced samples do not yield a valid
+            crossing on R_map. In that case, the same branch is re-traced outward
+            from the station using AraSim, and the crossing is determined from
+            those traced samples. Falls back to straight-line (SL) only if no valid
+            RT crossing survives, or if the mapped RT elevation is unphysical for
+            plotting.
 
-          - R solution: shown on map if findPaths returns 2 solutions AND the
-            reflected path crosses R_map. Falls back to SL if:
-              (a) findPaths returns only 1 solution — the reflected path
-                  physically does not exist for this source-station geometry, OR
-              (b) the reflected path never crosses R_map — same geometric
-                  condition as the D fallback above.
+          - R solution: shown if findPaths returns at least two solutions and the
+            requested reflected / refracted branch yields a valid RT crossing on
+            R_map. Falls back to SL if:
+              (a) only one solution exists, so the R branch is absent,
+              (b) neither the source->station nor the station->outward traced
+                  samples yield a valid crossing on R_map, or
+              (c) the mapped RT elevation is unphysical for plotting.
 
         Parameters
         ----------
@@ -778,37 +1104,40 @@ class AraGeom:
             Landmark names to include. Supported values:
             'ICL', 'IC22S', 'SPT', 'IC1S', 'SPIce', 'WT', 'SPRESSO'.
             Pass ['all'] to include all of the above.
-            Default: ['IC22S', 'ICL', 'SPRESSO'].
+            Default is ['IC22S', 'ICL', 'SPRESSO'].
         R_map : float
             Reconstruction sphere radius corresponding to the map, in meters.
+            Must be provided and must be positive.
         list_of_cal_pulser_indices : list of int, optional
             Calpulser indices to include, e.g. [0, 1, 2, 3].
-            Pass ['all'] for all four. Default: [1, 3].
+            Pass ['all'] for all four. Default is [1, 3].
         spice_depth : float, optional
-            Depth of the SPIce pulser in meters. Required if 'SPIce' is in
-            list_of_landmarks.
+            Depth of the SPIce pulser, in meters. Required if 'SPIce' is included.
         solution : int
             Requested ray solution:
-              - 0 : direct path (shortest propagation time), for direct maps
-              - 1 : reflected path (second-shortest propagation time), for reflected maps
+              - 0 : direct path (shortest propagation time)
+              - 1 : reflected path (second-shortest propagation time)
 
         Returns
         -------
         collect : dict
-            Keys are landmark name strings. Values are [r, elevation, azimuth]
-            where r is the straight-line distance in meters, elevation and
+            Keys are landmark-name strings. Values are [r, elevation, azimuth],
+            where r is the straight-line distance in meters, and elevation and
             azimuth are the ray-traced (or SL fallback) angles in degrees.
             Also includes:
-              - 'critical_angle'    : geometric critical elevation angle, in degrees
               - 'critical_angle_rt' : ray-traced critical elevation angle mapped
                                       onto R_map, in degrees
+              - '_marker_status'    : plotting status for each landmark
         """
-        
+        if R_map is None:
+            raise ValueError("R_map must be provided to get_known_landmarks().")
+        if R_map <= 0:
+            raise ValueError(f"R_map must be positive, got {R_map}.")
 
         if list_of_landmarks is None:
             list_of_landmarks = ["IC22S", "ICL", "SPRESSO"]
         elif list_of_landmarks == ["all"]:
-            list_of_landmarks = ["ICL", "IC22S", "SPT", "IC1S", "WT", "SPRESSO"]
+            list_of_landmarks = ["ICL", "IC22S", "IC1S", "WT", "SPRESSO"] #"SPT" removed due to depth of SPT bug in AraRoot 
 
         if list_of_cal_pulser_indices is None:
             list_of_cal_pulser_indices = [1, 3]
@@ -819,20 +1148,17 @@ class AraGeom:
             list_of_landmarks.append("SPIce")
 
         collect = {}
+        marker_status = {}
         station_center = self.get_station_center()
-        
 
         def _resolve(name, source_xyz, station_center, R_sphere, solution):
-
             """
             Resolve one landmark to its apparent direction on the reconstruction sphere.
 
-            Computes the straight-line (SL) direction first — this is always valid
-            and serves as the fallback. Then attempts ray tracing via
+            Computes the straight-line (SL) direction first; this is always valid and
+            serves as the fallback. Then attempts ray tracing via
             get_raytraced_sphere_crossing_angles(). Falls back to SL with diagnostic
-            output if ray tracing fails for any of the reasons documented in
-            get_known_landmarks().
-
+            output if ray tracing fails for any of the reasons documented above.
 
             Parameters
             ----------
@@ -843,68 +1169,65 @@ class AraGeom:
                 in meters.
             station_center : array-like
                 Station center [x, y, z] in station-centric Cartesian coordinates,
-                in meters. 
-
+                in meters.
             R_sphere : float
                 Reconstruction sphere radius, in meters.
-
             solution : int
-                0 = direct path, 1 = reflected path. See get_known_landmarks().
+                0 = direct path, 1 = reflected path.
 
             Returns
             -------
             list
-                [r, elevation, azimuth] where r is the SL distance in meters,
-                and elevation and azimuth are in degrees. Ray-traced if successful,
-                straight-line fallback otherwise.
-
+                [r, elevation, azimuth], where r is the straight-line distance in
+                meters, and elevation / azimuth are in degrees. Ray-traced if
+                successful, straight-line fallback otherwise.
             """
             r_sl, elev_sl, az_sl = self.get_relative_cartesian_to_spherical(
                 station_center, source_xyz
             )
 
-
             rt_sols = self.get_raytraced_sphere_crossing_angles(
-                source_xyz    = source_xyz,
-                R_sphere      = R_sphere,
-                solution      = solution,
-                station_center= station_center,
+                source_xyz=source_xyz,
+                R_sphere=R_sphere,
+                solution=solution,
+                station_center=station_center,
             )
 
             if not rt_sols:
-                return [r_sl, elev_sl, az_sl] # Fallback to SL solution
-            
-            return [r_sl, rt_sols[0]["elevation"], rt_sols[0]["azimuth"]] #always the requested solution, either D or R.
+                marker_status[name] = "sl_fallback"
+                if hasattr(self, "_last_rt_fail_reason") and self._last_rt_fail_reason:
+                    print(f"[RAYTRACE FAIL] {name}: {self._last_rt_fail_reason}")
+                return [r_sl, elev_sl, az_sl]
 
+            marker_status[name] = (
+                "sl_fallback" if rt_sols[0].get("used_sl_fallback", False) else "raytraced"
+            )
 
-        
-        # Local Calpulsers
+            return [r_sl, rt_sols[0]["elevation"], rt_sols[0]["azimuth"]]
 
+        # Local calpulsers
         calpulser = self.get_local_CP(list_of_cal_pulser_indices)
         for cp in calpulser:
             collect[f"CP{cp}"] = _resolve(f"CP{cp}", calpulser[cp], station_center, R_map, solution)
         del calpulser
-        
-        # Distant pulsers
 
+        # Distant pulsers
         for pulser in ["IC22S", "IC1S", "SPIce"]:
             if pulser in list_of_landmarks:
                 this_pulser = self.get_distant_pulsers(pulser, spice_depth)
                 collect[pulser] = _resolve(pulser, this_pulser, station_center, R_map, solution)
 
         # South Pole surface landmarks
-
-        for known_loc in ["ICL", "WT", "SPRESSO", "SPT"]:
+        for known_loc in ["ICL", "WT", "SPRESSO"]: #"SPT" removed because of unknown depth, AraRoot SPT depth entry is incorrect 
             if known_loc in list_of_landmarks:
-                this_loc   = np.array(self.get_southpole_landmarks(known_loc))[0]
+                this_loc = np.array(self.get_southpole_landmarks(known_loc))[0]
                 st_centric = self.get_global_to_station_centric(this_loc[:3])
-                if known_loc == "SPT":
-                    st_centric[2] = 7.55984245e-02  # corrected SPT depth, meters, set to ICL depth 
+                #if known_loc == "SPT":
+                #    st_centric[2] = 7.55984245e-02  # SPT is removed from surface landmark list due to depth bug in AraRoot
                 collect[known_loc] = _resolve(known_loc, st_centric, station_center, R_map, solution)
 
-        
-        # Critical angle (ray traced and fall back SL solution)
-
+        # Ray-traced critical angle
         collect["critical_angle_rt"] = self.get_raytraced_critical_angle(R_map)
+        collect["_marker_status"] = marker_status
 
         return collect

--- a/araproc/framework/map_utilities.py
+++ b/araproc/framework/map_utilities.py
@@ -38,7 +38,6 @@ def get_corr_map_peak(the_map  = None):
     return peak_corr, peak_phi, peak_theta
 
 
-
 def load_raytrace_model(arasimsrc=None):
     """
     Load and initialize the AraSim ray-tracing model into ROOT's interpreter.
@@ -193,7 +192,6 @@ class AraGeom:
         # Station information
         self.st_info = self.geomTool.getStationInfo(self.station_id)
 
-
     def get_station_center(self, excluded_channels=None):
         """
         Calculates the average x, y, and z coordinates of antennas for a given station.
@@ -268,6 +266,7 @@ class AraGeom:
             return np.asarray([easting, northing, elevation]) - self.SUR_TO_GLOB
         return np.asarray([easting, northing]) - self.SUR_TO_GLOB[:2]
     
+
     def get_array_from_lat_long(self,latitude,longitude):
         """
         Convert latitude/longitude to ARA array coordinates.
@@ -288,7 +287,6 @@ class AraGeom:
         easting = self.geomTool.getEastingFromLatLong(latitude,longitude)
         northing = self.geomTool.getNorthingFromLatLong(latitude,longitude)
         return np.array([northing, easting,0])
-
 
 
     def get_global_to_station_centric(self, array_coords):
@@ -339,13 +337,12 @@ class AraGeom:
                 landmarks.append([corner[0], corner[1], corner[2]])
         elif landmark_type == "SPRESSO":
             landmarks.append(self.get_array_from_lat_long(-89.93120, 144.51249))
-        #elif landmark_type == "SPT":
-        #    corner = self.geomTool.getSouthPoleTelescope()
-        #    landmarks.append([corner[0], corner[1], corner[2]])
+        elif landmark_type == "SPT":
+            corner = self.geomTool.getSouthPoleTelescope()
+            landmarks.append([corner[0], corner[1], corner[2]])
         else:
             raise ValueError(f"Unknown landmark type: {landmark_type}")
         return landmarks
-
 
 
     def get_distant_pulsers(self, pulser_name, spice_depth=None):
@@ -416,8 +413,7 @@ class AraGeom:
         phi = np.degrees(np.arctan2(y, x))
         return r, 90 - theta, phi
 
-
-
+ 
     def get_critical_angle(self):
         """
         Returns
@@ -435,74 +431,63 @@ class AraGeom:
 
 
 
-
     def _circle_intersect(self, p0, v, radius, t_max=1.0):
         """
-        Find the first intersection of a straight line segment (or ray) with the
-        station-centered circle x^2 + z^2 = radius^2 in the local propagation plane.
-
-        Here, p(t) = p0 + t*v parameterizes only the local straight segment used for
-        interpolation between two successive sampled ray-trace points. It does NOT
-        represent the full curved ray-trace path. The full path comes from AraSim;
-        this helper is used only to determine where that discretely sampled path
-        crosses the reconstruction circle more accurately than choosing the sampled
-        point whose radius is merely closest to R_sphere.
-
-        In the local propagation plane:
-          - x >= 0 : radial distance from the station, in meters
-          - z      : vertical offset from the station, in meters (positive upward)
-
-        Substituting p(t) into x^2 + z^2 = radius^2 gives:
-          a*t^2 + b*t + c = 0
-        with
-          a = |v|^2
-          b = 2 * dot(p0, v)
-          c = |p0|^2 - radius^2
-
-        The two roots are checked in increasing order so the nearest valid crossing
-        is returned first. Only roots with 0 <= t <= t_max are accepted.
+        Intersect the line segment p(t) = p0 + t*v with the circle x^2 + z^2 = radius^2
+        in the local (rho, dz) plane, for t in [0, t_max].
 
         Parameters
         ----------
-        p0 : tuple of float
-            Start point (x, z), in meters.
-        v : tuple of float
-            Direction vector (vx, vz) in the local (x, z) plane. For a finite
-            segment, pass p1 - p0.
+        p0 : (float, float)
+            (x0, z0) = (rho0, dz0)
+        v : (float, float)
+            (vx, vz) direction from p0 to p1 (segment vector)
         radius : float
-            Circle radius, in meters (= R_sphere or R_map).
-        t_max : float, optional
-            Upper bound on t. In this file, t_max = 1.0 is used for a finite
-            segment between successive sampled points.
+            Circle radius
+        t_max : float
+            Maximum allowed t (use 1.0 for segment endpoint)
 
         Returns
         -------
-        tuple or None
-            (x, z, t) for the first valid intersection, with x and z in meters,
-            or None if no valid intersection exists.
+        (x, z, t) or None
+            Intersection point and interpolation parameter t.
         """
-        x0, z0 = p0
-        vx, vz = v
+        # Unpack the starting point (rho0, dz0) and segment direction (drho, ddz).
+        x0, z0 = float(p0[0]), float(p0[1])
+        vx, vz = float(v[0]), float(v[1])
+        R = float(radius)
 
+        # Substitute x(t)=x0+t*vx and z(t)=z0+t*vz into x^2+z^2=R^2:
+        # (vx^2+vz^2) t^2 + 2(x0*vx+z0*vz) t + (x0^2+z0^2-R^2) = 0
         a = vx * vx + vz * vz
-        if a == 0.0:
-            return None  # zero-length segment / direction vector
+        if abs(a) < 1e-30: # Degenerate segment (zero length) => no unique intersection
+            return None
 
         b = 2.0 * (x0 * vx + z0 * vz)
-        c = x0 * x0 + z0 * z0 - radius * radius
-        disc = b * b - 4.0 * a * c
-        if disc < 0.0:
-            return None  # no real intersection with the circle
+        c = x0 * x0 + z0 * z0 - R * R
 
-        sq = np.sqrt(disc)
-        for t in ((-b - sq) / (2.0 * a), (-b + sq) / (2.0 * a)):
-            if 0.0 <= t <= t_max:
-                x = x0 + t * vx
-                z = z0 + t * vz
-                if x >= 0.0:  # radial distance from station must be non-negative
-                    return (x, z, t)
+        disc = b * b - 4.0 * a * c # find Discriminant
+        if disc < 0.0: # Discriminant < 0 means no real intersection with the circle
+            return None
 
-        return None
+        # Compute the two quadratic roots (potential entry/exit points)
+        s = np.sqrt(disc)
+
+        # Two solutions; choose the one that lies on the segment and is closest to p0 (smallest t >= 0)
+
+        t_candidates = [(-b - s) / (2.0 * a), (-b + s) / (2.0 * a)]
+
+        # Keep only roots that lie within the segment parameter range.
+        t_valid = [t for t in t_candidates if 0.0 <= t <= float(t_max)]
+
+        if not t_valid: # Intersections exist on the infinite line, but not on this segment portion
+            return None
+
+        t = min(t_valid) # Choose the first intersection along the segment (closest to p0)
+        # Evaluate the intersection point p(t) = p0 + t*v
+        x = x0 + t * vx
+        z = z0 + t * vz
+        return (float(x), float(z), float(t))
 
 
     def _find_sphere_crossing_from_samples(
@@ -512,60 +497,47 @@ class AraGeom:
         z_ref,
         radius,
         reverse_search=False,
-    ):
+        ):
+        
         """
-        Find the intersection of sampled ray-trace points with the station-centered
-        circle x^2 + z^2 = radius^2 in the local propagation plane.
+        Find the intersection of sampled ray-trace points with the reconstruction
+        sphere (circle in the 2D propagation plane) centered at the station.
 
-        This helper is shared by:
-          - get_raytraced_sphere_crossing_angles()
-          - get_raytraced_critical_angle()
+        Geometry
+        --------
+        Using local coordinates:
+            rho = xs
+            dz  = zs - z_ref
 
-        It finds the first pair of consecutive sampled points that bracket the desired radius and
-        then interpolates the crossing on that finite segment using
-        self._circle_intersect().
+        The reconstruction circle is:
+            rho^2 + dz^2 = radius^2
+        i.e.
+            rho^2 + (z - z_ref)^2 = radius_map^2   
 
         Parameters
         ----------
         xs : array-like
-            Sampled horizontal coordinates in the local propagation plane, in meters.
+            Sampled horizontal coordinates rho (meters), station-centered in the propagation plane.
+            For backward traces from the station: xs starts near 0 and increases outward.
+            For forward traces (source to station path): station-centered rho is passed, 
+            e.g. rho = r_src - x.
         zs : array-like
-            Sampled vertical coordinates in the local propagation plane, in meters.
+            Sampled absolute z coordinates (meters) in station-centric coordinates.
         z_ref : float
-            Reference station depth, in meters, used to convert z samples into
-            station-centered vertical offsets dz = z - z_ref.
+            Station z (meters). Used to compute dz = z - z_ref.
         radius : float
-            Target circle / sphere radius, in meters.
-        reverse_search : bool, optional
-            If True, search from the end of the sampled path backward. This is used
-            for source->station traces, where the desired crossing is the outermost
-            one encountered before arriving at the station (for finding crossing point with the radius map for source
-            within the radius map. 
-
-            Example:
-                For a source outside the map radius (e.g., r = 1000 m) and
-                R_sphere = 300 m, the sampled distances along the ray may look like:
-                    1000 → 800 → 500 → 350 → 280 → 100 → 0 (station)
-                The crossing of R_sphere occurs between 350 → 280.
-                We search backward to select this crossing before reaching
-                the station.
-
-            If False, search from the beginning forward. This is used for
-            station->outward traces (for finding ray-traced critical angle)
-            Example:
-                For an outward trace starting at the station (r = 40m) with
-                R_sphere = 300 m, the sampled distances may look like:
-                    40 → 100 → 150 → 280 → 350 → 500
-                The crossing of R_sphere occurs between 280 → 350.
-                We search forward to select this first crossing after leaving
-                the station.
+            Reconstruction Map radius (meters).
+        reverse_search : bool, default False
+            If True, pick the crossing closest to the far/source side (useful for forward traces).
+            If False, pick the first crossing encountered moving outward from the station.
 
         Returns
         -------
-        tuple
-            (inter, i_cross), where:
-              - inter is (x_cross, z_cross, t) from self._circle_intersect(), or None
-              - i_cross is the bracketing segment index, or None if no crossing exists
+        inter : tuple or None
+            (rho_cross, dz_cross, t) where t in [0,1] is the interpolation parameter along the
+            chosen segment. dz_cross is relative to z_ref.
+        i_cross : int or None
+            Segment index i for the segment (i-1 -> i) containing the intersection.
         """
         xp = np.asarray(xs, dtype=float)
         dz = np.asarray(zs, dtype=float) - float(z_ref)
@@ -575,31 +547,20 @@ class AraGeom:
 
         d = np.hypot(xp, dz)
 
-        if reverse_search:
-            # Samples run from source toward station: outside -> inside.
-            # We want the last crossing before reaching the station.
-            i_cross = next(
-                (i for i in range(len(d) - 1, 0, -1) if d[i] <= radius < d[i - 1]),
-                None,
-            )
-            if i_cross is None:
-                return None, None
+        # Find ALL candidate crossing segments by sign change 
+        crossing_indices = [
+            i for i in range(1, len(d))
+            if (d[i - 1] - float(radius)) * (d[i] - float(radius)) <= 0.0
+        ]
+        if not crossing_indices:
+            return None, None
 
-            p0 = (float(xp[i_cross - 1]), float(dz[i_cross - 1]))  # outside
-            p1 = (float(xp[i_cross]),     float(dz[i_cross]))      # inside
+        i_cross = crossing_indices[-1] if reverse_search else crossing_indices[0]
 
-        else:
-            # Samples run outward from the station: inside -> outside.
-            # We want the first crossing after leaving the station.
-            i_cross = next(
-                (i for i in range(1, len(d)) if d[i - 1] <= radius < d[i]),
-                None,
-            )
-            if i_cross is None:
-                return None, None
+        # Segment endpoints in local (rho, dz)
+        p0 = (float(xp[i_cross - 1]), float(dz[i_cross - 1])) # outside
+        p1 = (float(xp[i_cross]),     float(dz[i_cross]))     # inside
 
-            p0 = (float(xp[i_cross - 1]), float(dz[i_cross - 1]))  # inside
-            p1 = (float(xp[i_cross]),     float(dz[i_cross]))      # outside
 
         inter = self._circle_intersect(
             p0,
@@ -608,7 +569,128 @@ class AraGeom:
             t_max=1.0,
         )
 
+        # If interpolation failed on the chosen segment, try other candidates
+        if inter is None:
+            for i in crossing_indices:
+                p0 = (float(xp[i - 1]), float(dz[i - 1])) # inside
+                p1 = (float(xp[i]),     float(dz[i]))     # outside
+                inter = self._circle_intersect(
+                    p0,
+                    (p1[0] - p0[0], p1[1] - p0[1]),
+                    float(radius),
+                    t_max=1.0,
+                )
+                if inter is not None:
+                    return inter, i
+            return None, None
+
         return inter, i_cross
+
+    def _find_sphere_crossing_exact(self, xs, zs, z_rec, R):
+        """
+        Exact segment-wise intersection with circle:
+            x^2 + (z - z_rec)^2 = R^2
+
+        Returns
+        -------
+        inter : tuple or None
+            (x_cross, dz_cross)
+        seg_idx : int or None
+            segment index i for (i-1 -> i)
+        """
+
+
+        """
+        Compute the intersection of a sampled ray path with the reconstruction circle
+        (sphere cross-section) by solving the quadratic exactly on each sample segment.
+
+        Geometry / units
+        ---------------
+        - xs is station-centered horizontal distance (rho) in meters.
+        - zs is absolute z in meters (station-centric coordinates).
+        - z_rec is the station center (receiver) z (circle center) in meters
+        - R is the Map radius in meters. 
+
+        The circle condition is:
+            rho^2 + (z - z_rec)^2 = R^2
+        Define dz = (z - z_rec), then:
+            rho^2 + dz^2 = R^2
+
+        Method:
+        ---------
+        For each segment between consecutive samples (i-1 -> i), the parametric form is:
+            rho(t) = rho0 + t*(rho1 - rho0)
+            dz(t)  = dz0  + t*(dz1  - dz0)
+        for t in [0, 1]. We solve:  rho(t)^2 + dz(t)^2 = R^2
+        and select the first valid intersection encountered in the provided ordering of samples.
+
+        Parameters
+        ----------
+        xs, zs : array-like
+            Sampled points along the ray in the 2D propagation plane:
+              - xs: rho (m)
+              - zs: absolute z (m)
+            Typically ordered from station outward for backward traces.
+        z_rec : float
+            Station z coordinate (m), used to compute dz = z - z_rec.
+        R : float
+            Reconstruction radius (m).
+
+        Returns
+        -------
+        inter : tuple or None
+            (rho_cross, dz_cross) where:
+              - rho_cross is in meters
+              - dz_cross = z_cross - z_rec is in meters
+            Returns None if no segment intersects the circle.
+        seg_idx : int or None
+            Segment index i such that the crossing lies on the segment from (i-1) to i.
+        """
+        xs = np.asarray(xs, dtype=float)
+        zs = np.asarray(zs, dtype=float)
+        if xs.size < 2:
+            return None, None
+
+        dzs = zs - float(z_rec) # Convert absolute z to station-relative dz for the circle equation.
+        R = float(R)
+
+        # Look segment-by-segment and solve for an intersection on each segment.
+        for i in range(1, len(xs)):
+            x0, dz0 = float(xs[i - 1]), float(dzs[i - 1])
+            x1, dz1 = float(xs[i]),     float(dzs[i])
+
+            # Segment direction vector (drho, ddz)
+            dx = x1 - x0
+            ddz = dz1 - dz0
+
+            # Plug rho(t)=x0+t*dx and dz(t)=dz0+t*ddz into rho(t)^2 + dz(t)^2 = R^2:
+            # -> a t^2 + b t + c = 0
+            a = dx * dx + ddz * ddz
+            if abs(a) < 1e-30: # Degenerate segment (two identical points); skip.
+                continue
+
+            b = 2.0 * (x0 * dx + dz0 * ddz)
+            c = x0 * x0 + dz0 * dz0 - R * R
+
+            disc = b * b - 4.0 * a * c # Discriminant determines whether the segment line intersects the circle.
+            if disc < 0.0: # No real intersection for this segment
+                continue
+
+            # Two candidate roots (enter/exit); keep only those lying on the segment t in [0,1]
+            s = np.sqrt(disc)
+            t_candidates = [(-b - s) / (2.0 * a), (-b + s) / (2.0 * a)]
+            t_valid = [t for t in t_candidates if 0.0 <= t <= 1.0]
+            if not t_valid:
+                continue
+
+            t = min(t_valid) # Choose the earliest intersection along this segment.
+            # Convert back to intersection point in (rho, dz).
+            x = x0 + t * dx
+            dz = dz0 + t * ddz
+            return (float(x), float(dz)), int(i)
+
+        # No segment intersected the circle.
+        return None, None
 
 
     def get_raytraced_sphere_crossing_angles(
@@ -620,93 +702,121 @@ class AraGeom:
         frequency=0.5,
         polarization=0.0,
         station_center=None,
-    ):
+        ):
+
         """
-        Find the apparent direction of a source on a reconstruction sphere via ray tracing.
+        Ray-trace a source to station path using AraSim and return the apparent direction
+        of the ray at its intersection with the reconstruction sphere of radius R_sphere.
 
-        The source is ray traced to the station center using AraSim's TraceFinder.
-        The selected ray branch is intersected with the reconstruction sphere of
-        radius R_sphere centered on the station. That sphere crossing defines the
-        apparent direction (elevation, azimuth) that should be overlaid on the sky map.
+        Coordinate conventions / units
+        ------------------------------
+        All distances are in meters and angles returned are in degrees.
 
-        If the source->station traced samples do not themselves cross R_sphere
-        (for example because the source lies inside R_sphere, or because the sampled
-        branch reaches the station before crossing the sphere), the same branch is
-        re-traced outward from the station using the branch receiptAngle. The sphere
-        crossing is then determined from those outward ray-traced samples.
+        Inputs:
+        - source_xyz: (x, y, z) in station-centric Cartesian coordinates (m).
+          z is the absolute station-centric depth coordinate.
+        - station_center: (x, y, z) in station-centric cartesian coordinates (m).
+          If None, uses self.get_station_center().
+        - R_sphere: reconstruction sphere radius (m), centered at the station.
+ 
+        - rho is the station-centered horizontal distance in that plane (m), rho >= 0
+        - dz = z - z_station (m)
 
-        If the mapped elevation lies outside the physical plotting range [-90, +90]
-        degrees, the straight-line (SL) direction is used only as a plotting fallback
-        and is flagged accordingly.
+        The reconstruction sphere in the (rho, z) plane is:
+            rho^2 + (z - z_station)^2 = R_sphere^2
+        i.e. rho^2 + dz^2 = R_sphere^2.
 
-        Ray solutions are identified only by propagation-time ordering:
-          - shortest TOF  -> label 'D' (direct)
-          - second TOF    -> label 'R' (reflected / refracted)
+        How this works ?
+        ---------------------------------
+        1) Use AraSim TraceFinder::findPaths to obtain ray solutions between source and station.
+           Solutions are ordered by time-of-flight; Hence:
+             - solution=0 -> 'D' (shortest TOF, "direct")
+             - solution=1 -> 'R' (second TOF, "refracted/alternate")
+        2) Trace the chosen solution with rt_doTrace_savePoints to obtain sampled points.
+        3) Determine where the sampled ray intersects the reconstruction circle:
+           - Try a forward trace (source to station) converted to station-centered rho.
+             For forward traces we select the "outer" crossing (reverse_search=True).
+           - If no crossing is found (can happen when the source lies inside the Radius map of interest),
+             do a backward trace outward from the station using a folded receiptAngle and
+             take the first outward crossing (reverse_search=False).
+
+        Returned direction definition
+        -----------------------------
+        The returned elevation is computed at the sphere-crossing point as:
+            elevation = atan2(dz_cross, rho_cross)  [degrees]
+        where dz_cross = (z_cross - z_station) and rho_cross is the station-centered horizontal
+        distance at the crossing.
 
         Parameters
         ----------
         source_xyz : array-like
-            Source position [x, y, z] in station-centric Cartesian coordinates,
-            in meters.
+            Source coordinates [x, y, z] (m), station-centric.
         R_sphere : float
-            Reconstruction sphere radius, in meters. Must be positive.
-        accuracy : float, optional
-            Convergence tolerance passed to AraSim findPaths (dimensionless).
-            Default is 0.001.
-        solution : int, optional
-            Requested solution type:
-              - 0 : direct path (shortest propagation time)
-              - 1 : reflected / refracted path (second-shortest propagation time)
-        frequency : float, optional
-            Signal frequency passed to the AraSim ray tracer, in GHz.
-            Default is 0.5 GHz.
-        polarization : float, optional
-            Signal polarization passed to the AraSim ray tracer, in radians.
-            Default is 0.0.
-        station_center : array-like or None, optional
-            Station center [x, y, z] in station-centric Cartesian coordinates,
-            in meters. If None, the internally stored station center is used.
+            Reconstruction sphere radius (m), must be > 0.
+        accuracy : float, default 0.001
+            Convergence tolerance passed to TraceFinder::findPaths.
+        solution : int, default 0
+            0 selects the shortest TOF solution ('D'); 1 selects the second ('R').
+        frequency : float, default 0.5
+            Frequency passed to the ray tracer (AraSim units; typically GHz in this interface).
+        polarization : float, default 0.0
+            Polarization argument passed to the ray tracer.
+        station_center : array-like or None
+            Station center [x, y, z] (m). If None, computed from geometry.
 
         Returns
         -------
         list of dict
-            Each dict corresponds to one valid ray-traced solution and contains:
-              - 'label'            : 'D' or 'R'
-              - 'elevation'        : elevation angle on R_sphere, in degrees
-              - 'azimuth'          : azimuth angle, in degrees
-              - 'tof'              : propagation time, in nanoseconds
-              - 'path_len'         : ray path length, in meters
-              - 'allowedUsed'      : AraSim reflection-mode flag
-              - 'used_sl_fallback' : bool, True only if plotting fell back to SL
+            A list with 0 or 1 entries. On success, one dict is returned:
+              - 'label' : 'D' or 'R'
+              - 'elevation' : float (deg), elevation at the sphere crossing
+              - 'azimuth' : float (deg), azimuth of source direction
+              - 'tof' : float (ns), time of flight from AraSim pathTime
+              - 'path_len' : float, path length from AraSim pathLen
+              - 'allowedUsed' : int, reflection mode used
+              - 'used_sl_fallback' : bool, True only if an unphysical angle forced SL fallback
+
+            If no valid ray solution/crossing is found, returns [] and sets
+            self._last_rt_fail_reason.
         """
+
         if R_sphere is None:
             raise ValueError("R_sphere must be provided to get_raytraced_sphere_crossing_angles().")
         if R_sphere <= 0:
             raise ValueError(f"R_sphere must be positive, got {R_sphere}.")
+
+        # Source/receiver coordinates in station-centric cartesian frame (meters)
 
         src = np.asarray(source_xyz, dtype=float)
         rec = np.asarray(
             station_center if station_center is not None else self.get_station_center(),
             dtype=float,
         )
+        # Extract sphere radius and absolute z (meters)
         R = float(R_sphere)
-
         z_src = float(src[2])
         z_rec = float(rec[2])
+        # --- Convert 3D source position to 2D propagation-plane quantities ---
+        # r_src: station-centered horizontal distance to the source (meters)
+        # az_phi: azimuth angle of the source in station coordinates (radians)
 
         dx = float(src[0] - rec[0])
         dy = float(src[1] - rec[1])
         r_src = float(np.hypot(dx, dy))
         az_phi = float(np.arctan2(dy, dx))
-
+        # --- Reset last-raytrace diagnostics (for debug) ---
+        self._last_rt_npaths = 0
+        self._last_rt_paths = []
+        self._last_rt_fail_reason = None
+        # --- Configure AraSim vectors in the ray-tracer propagation plane ---
         ROOT._rt_src.SetXYZ(r_src, 0.0, z_src)
         ROOT._rt_rec.SetXYZ(0.0, 0.0, z_rec)
 
-        # findPaths searches in AraSim's 2D cylindrical propagation plane and
-        # returns the available ray solutions. We later label them only by TOF:
-        # shortest -> D, second-shortest -> R.
+        
         sol_cnt = ctypes.c_int()
         sol_err = ctypes.c_int()
+        allowed_used = int(ROOT.RayTrace.SurfaceReflection)
+
         paths = ROOT._rt_tf.findPaths(
             ROOT._rt_src,
             ROOT._rt_rec,
@@ -714,14 +824,10 @@ class AraGeom:
             ROOT.TMath.Pi() / 2,
             sol_cnt,
             sol_err,
-            int(ROOT.RayTrace.SurfaceReflection),
+            allowed_used,
             float(accuracy),
         )
-
-        self._last_rt_npaths = 0
-        self._last_rt_paths = []
-        self._last_rt_fail_reason = None
-
+        # Handle "no solutions" or raytracer errors 
         if sol_err.value != 0 or not paths or len(paths) == 0:
             self._last_rt_fail_reason = (
                 f"findPaths error (serr={sol_err.value})"
@@ -729,25 +835,16 @@ class AraGeom:
                 else "findPaths returned zero solutions"
             )
             return []
-
+        #Sort solutions by time-of-flight (TOF) and label them by order
         sorted_paths = sorted(paths, key=lambda p: float(p.pathTime))
-
-        self._last_rt_npaths = len(sorted_paths)
-        self._last_rt_paths = [
-            {
-                "tof": float(p.pathTime) * 1e9,
-                "path_len": float(p.pathLen),
-                "launchAngle": float(p.launchAngle),
-            }
-            for p in sorted_paths
-        ]
 
         labeled = []
         if len(sorted_paths) >= 1:
-            labeled.append((sorted_paths[0], "D"))
+            labeled.append((sorted_paths[0], "D")) # shortest TOF
         if len(sorted_paths) >= 2:
-            labeled.append((sorted_paths[1], "R"))
+            labeled.append((sorted_paths[1], "R"))  # second-shortest TOF
 
+        #Select which branch to trace based on 'solution' argument
         if solution == 0:
             to_trace = [(p, l) for p, l in labeled if l == "D"]
         elif solution == 1:
@@ -758,18 +855,14 @@ class AraGeom:
         else:
             raise ValueError(f"solution must be 0 or 1, got {solution}.")
 
-        allowed_used = int(ROOT.RayTrace.SurfaceReflection)
-
-        # Straight-line direction is used only as a last-resort plotting fallback
-        # if the mapped RT elevation lies outside [-90, +90] degrees.
+        # Straight-line (SL) direction computed once; used only as a fallback
         _, elev_sl, az_sl = self.get_relative_cartesian_to_spherical(rec, src)
 
         out = []
-        for path, label in to_trace:
+        for path, label in to_trace: 
             used_sl_fallback = False
-
-            # First trace: source -> station along the chosen TOF-ordered branch.
-            sol_error = ctypes.c_int(0)
+            #Forward trace (source to station) and save all intermediate ray traced points
+            sol_error = ctypes.c_int(0) 
             ROOT.rt_doTrace_savePoints(
                 z_src,
                 float(path.launchAngle),
@@ -779,21 +872,23 @@ class AraGeom:
                 float(polarization),
                 sol_error,
             )
+            #Retrieve the saved ray samples from the C++ helper vectors.
+            xs = np.asarray(list(ROOT.rt_get_x()), dtype=float) # rho-like coordinate along the trace
+            zs = np.asarray(list(ROOT.rt_get_z()), dtype=float) # absolute z samples
 
-            xs = np.asarray(list(ROOT.rt_get_x()), dtype=float)
-            zs = np.asarray(list(ROOT.rt_get_z()), dtype=float)
-
-            if sol_error.value != 0 or len(xs) < 2:
-                print(f"[TRACE FAIL] label={label}  sol_error={sol_error.value}  npts={len(xs)}")
+            if sol_error.value != 0 or len(xs) < 2:  # If the forward trace failed, skip this branch.
+                self._last_rt_fail_reason = (
+                    f"forward trace failed for label={label}: sol_error={sol_error.value}, npts={len(xs)}"
+                )
                 continue
 
-            # Convert source->station samples into receiver-centered coordinates.
-            # xp_forward is radial distance from station in meters.
+            # Convert forward-trace rho coordinate into station-centered rho.
+            # In this forward trace, x increases from source to station, so station-centered rho is (r_src - x).
             xp_forward = r_src - xs
 
-            # For source->station samples, search from the end backward because
-            # the path terminates at the station and we want the outer sphere crossing.
-            inter, i_cross = self._find_sphere_crossing_from_samples(
+            #Find sphere crossing from the forward samples
+            # reverse_search=True chooses the crossing closer to the station side for forward-ordered points.
+            inter, _ = self._find_sphere_crossing_from_samples(
                 xp_forward,
                 zs,
                 z_rec,
@@ -801,34 +896,37 @@ class AraGeom:
                 reverse_search=True,
             )
 
+            # If no forward crossing: backward trace outward from station
             if inter is None:
-                print(
-                    f"[BACKTRACE INFO] label={label}  "
-                    f"n_ray_solutions={self._last_rt_npaths}  "
-                    f"forward_trace_found_no_crossing=True  "
-                    f"R_sphere={R:.3f} m  "
-                    f"source_r={r_src:.3f} m  "
-                    f"source_z={z_src:.3f} m"
-                )
-
+                # Need receiptAngle to trace back outward along the same branch.
                 if not hasattr(path, "receiptAngle"):
                     self._last_rt_fail_reason = (
-                        f"ray-traced solution exists for label={label}, but no forward crossing "
-                        f"was found for R_sphere={R:.3f} m and receiptAngle is unavailable "
-                        f"for backward tracing"
+                        f"no forward crossing for label={label} and receiptAngle unavailable for backward tracing"
                     )
-                    print(f"[BACKTRACE FAIL] {self._last_rt_fail_reason}")
                     continue
 
-                # Re-trace the same branch outward from the station using AraSim,
-                
-                sol_error_back = ctypes.c_int(0)
-                r_back_target = max(float(R) + 50.0, float(r_src) + 50.0)
+                # Fold the receipt angle into [0, pi/2] for a valid outward-launch angle.
+                theta_receipt = float(path.receiptAngle)
+                theta_back = theta_receipt if theta_receipt <= np.pi / 2 else (np.pi - theta_receipt)
 
+                # Backward tracing distance: ensure it's far enough to cross the R_map circle
+
+                # Choose a sufficiently distant backward-trace target so the station to outward ray is long enough
+                # (and has enough sampled points) to reliably cross the reconstruction circle of radius R.
+                # - 3*R: is choden to ensure we trace several sphere radii outward
+                # - r_src+50 m: ensures we trace at least beyond the source horizontal range (plus margin) when R is small
+                # - 100 m: absolute minimum to avoid too-short traces for very small R
+
+                r_back_target = max(3.0 * R, r_src + 50.0, 100.0)
+                z_back_target = z_rec
+
+                
+                # Backward trace (station to outward) and save all intermediate points.
+                sol_error_back = ctypes.c_int(0)
                 ROOT.rt_doTrace_savePoints(
                     z_rec,
-                    float(path.receiptAngle),
-                    ROOT.RayTrace.rayTargetRecord(float(z_src), r_back_target),
+                    float(theta_back),
+                    ROOT.RayTrace.rayTargetRecord(float(z_back_target), float(r_back_target)),
                     allowed_used,
                     float(frequency),
                     float(polarization),
@@ -838,50 +936,45 @@ class AraGeom:
                 xs_back = np.asarray(list(ROOT.rt_get_x()), dtype=float)
                 zs_back = np.asarray(list(ROOT.rt_get_z()), dtype=float)
 
+
+                 # If backward trace failed, skip this branch
                 if sol_error_back.value != 0 or len(xs_back) < 2:
                     self._last_rt_fail_reason = (
-                        f"backward trace failed for label={label}: "
-                        f"sol_error={sol_error_back.value}, npts={len(xs_back)}"
+                        f"backward trace failed for label={label}: sol_error={sol_error_back.value}, npts={len(xs_back)}"
                     )
-                    print(f"[BACKTRACE FAIL] {self._last_rt_fail_reason}")
                     continue
-
-                inter, i_cross_back = self._find_sphere_crossing_from_samples(
+                # Find the first outward crossing on the backward-trace samples.
+                inter, _ = self._find_sphere_crossing_from_samples(
                     xs_back,
                     zs_back,
                     z_rec,
                     R,
                     reverse_search=False,
                 )
-
-                if inter is not None:
-                    print(
-                        f"[BACKTRACE OK] label={label}  "
-                        f"R_sphere={R:.3f} m  "
-                        f"crossing_index={i_cross_back}  "
-                        f"npts={len(xs_back)}"
-                    )
-                else:
+                # If still no crossing, give up on this RT solution
+                #record the failure reason and print it
+                # so we can see why we fell back / skipped this branch.
+                if inter is None:
                     self._last_rt_fail_reason = (
-                        f"ray-traced solution found for label={label} "
-                        f"(n_ray_solutions={self._last_rt_npaths}), but neither forward "
-                        f"nor backward traced samples crossed R_sphere={R:.3f} m"
+                        f"ray-traced solution found for label={label}, but neither forward nor backward samples crossed "
+                        f"R_sphere={R:.3f} m"
                     )
-                    print(f"[BACKTRACE FAIL] {self._last_rt_fail_reason}")
                     continue
-
+            # convert crossing point (rho_cross, dz_cross) into elevation-azimuth
             xp_c, dz_c, _ = inter
-            elev = float(np.degrees(np.arctan2(dz_c, xp_c)))
-            az = float(np.degrees(az_phi))
+            elev = float(np.degrees(np.arctan2(dz_c, xp_c))) # elevation at sphere crossing (deg)
+            az = float(np.degrees(az_phi))   # azimuth defined by 3D source position (deg)
 
+            # Sanity check: if the mapped RT elevation is unphysical (outside [-90, 90]),
+            # fall back to the straight-line direction. This should not happen, but keeping it as a safeguard.
             if not (-90.0 <= elev <= 90.0):
-                self._last_rt_fail_reason = (
-                    f"ray-traced elevation {elev:.3f} deg outside [-90, 90]; "
-                    f"used straight-line fallback for plotting"
-                )
-                elev, az = elev_sl, az_sl
+                elev, az = float(elev_sl), float(az_sl)
                 used_sl_fallback = True
+                self._last_rt_fail_reason = (
+                    f"ray-traced elevation outside [-90,90]; used SL fallback for label={label}"
+                )
 
+            # Record output dictionary for this chosen solution branch
             out.append(
                 {
                     "label": label,
@@ -894,171 +987,151 @@ class AraGeom:
                 }
             )
 
+        # If everything failed, set a final diagnostic reason.
         if not out and not self._last_rt_fail_reason:
             self._last_rt_fail_reason = f"no valid crossing to R_sphere={R:.3f} m survived"
 
         return out
 
 
+    def get_raytraced_critical_angle(self, R_sphere, frequency=0.5, polarization=0.0):
 
-    def get_raytraced_critical_angle(
-        self,
-        R_sphere,
-        frequency=0.5,
-        polarization=0.0,
-    ):
         """
-        Map the critical reception angle onto the reconstruction sphere using the
-        AraSim ray tracer.
+        Compute the apparent critical-angle direction on the reconstruction sphere
+        by ray tracing a near-critical ray launched from the station.
 
-        The critical angle is first defined locally at the station via
-        get_critical_angle(), which returns the geometric critical elevation
-        in degrees. That local critical direction is then traced outward with
-        AraSim, and the apparent critical angle on the sky map is defined by
-        where that ray-traced trajectory crosses the reconstruction sphere of
-        radius R_sphere centered on the station.
+        Method : 
+        ------------------------
+        The function:
+          1) computes the local geometric critical elevation at the station using
+             the refractive indices (air vs ice),
+          2) launches a ray from the station at that near-critical direction using AraSim,
+          3) determines where that ray intersects the reconstruction sphere 
+             of radius R_sphere centered at the station,
+          4) returns the elevation angle at that sphere-crossing point.
+          5) For "small" spheres (R_sphere less than the vertical distance to the turning
+          point), the ray intersects the sphere on the upward leg; this is handled via
+          exact segment-wise intersection in `_find_sphere_crossing_exact`.
 
-        The initial launch direction is obtained from get_critical_angle(),
-        which computes the geometric critical angle at the station depth using
-        the local index of refraction. This provides a first-order estimate of
-        the direction from which a critically refracted ray would arrive at the
-        station in a straight-line (locally uniform medium) approximation.
+        Coordinate conventions / units
+        ------------------------------
+        - All distances are in meters.
+        - Returned angle is degrees.
+        - z_rec = Station Center depth (z) coordinate (m).
+        - rho = horizontal distance from station (m), rho >= 0
+        - dz  = z - z_rec (m)
+        The reconstruction circle is:  rho^2 + dz^2 = R_sphere^2
 
-        This direction is then used to initialize the AraSim ray tracer at the
-        station depth. The full ray-traced trajectory accounts for the depth-
-        dependent refractive index profile n(z), allowing the curved ray path
-        corresponding to that critical condition to be followed through the ice.
-
-        The ray is launched from the station rather than from the surface. This
-        relies on ray-path reversibility: the outward-traced trajectory is the
-        time-reversed equivalent of a ray arriving at the station at the critical
-        angle. Using the station depth as the starting point ensures a well-defined
-        initial condition for the ray tracer and maintains consistency with how
-        other ray-traced directions are constructed in this module.
-
-        This function uses the same sampled sphere-crossing logic as
-        get_raytraced_sphere_crossing_angles():
-          1. Ray trace the trajectory outward from the station.
-          2. Search the traced (x, z) samples for a crossing of R_sphere.
-          3. Interpolate the crossing on the bracketing segment with
-             self._circle_intersect() via the shared helper
-             self._find_sphere_crossing_from_samples().
-
-        Unlike the source-mapping case, no source->station ray-tracing step is
-        required. The critical-angle trajectory is defined locally at the station,
-        so it can be traced directly outward from the station. Therefore only a
-        single outward ray trace is needed, and no fallback re-tracing is required.
-
-        The ray is traced continuously through the ice-air interface; reaching
-        z = 0 is not treated as a terminal condition. To ensure this, the outward
-        target is placed slightly above the surface.
-
-        Falls back to get_critical_angle() (geometric, no ray bending) only if
-        no valid ray-traced crossing on R_sphere can be determined, or if the
-        mapped ray-traced elevation is outside the physical plotting range
-        [-90, +90] degrees.
+        Returned value
+        --------------
+        The returned elevation is:  elevation = atan2(dz_cross, rho_cross)   [degrees]
+        where (rho_cross, dz_cross) is the intersection of the traced ray with the
+        reconstruction circle.
 
         Parameters
         ----------
         R_sphere : float
-            Reconstruction sphere radius, in meters. Must be positive.
-        frequency : float, optional
-            Signal frequency passed to the AraSim ray tracer, in GHz.
-            Default is 0.5 GHz.
-        polarization : float, optional
-            Signal polarization passed to the AraSim ray tracer, in radians.
-            Default is 0.0.
+            Reconstruction sphere radius (m), must be > 0.
+        frequency : float, default 0.5
+            Frequency passed to AraSim ray tracer (AraSim interface units; typically GHz).
+        polarization : float, default 0.0
+            Polarization argument passed to the ray tracer.
 
-        Returns
-        -------
-        float
-            Elevation angle, in degrees, where the ray-traced critical-angle
-            trajectory appears on the reconstruction sphere. Returns
-            get_critical_angle() only if no valid RT-based crossing can be obtained.
+        Notes
+        -----
+        - This function returns a ray-traced critical-angle elevation.
+        - If the AraSim trace fails (nonzero solver error / too few samples) or a turning point
+          cannot be identified, the function falls back to the geometric critical elevation at
+          the station (from `get_critical_angle()`). 
+        - We always expect the ray-traced critical angle result; the fallback is retained as 
+          a safeguard for unusual inputs.
+
         """
-        if R_sphere is None:
-            raise ValueError("R_sphere must be provided to get_raytraced_critical_angle().")
-        if R_sphere <= 0:
-            raise ValueError(f"R_sphere must be positive, got {R_sphere}.")
+
+
+        if R_sphere is None or R_sphere <= 0:
+            raise ValueError(f"R_sphere must be positive, got {R_sphere}")
 
         z_rec = float(self.get_station_center()[2])
         R = float(R_sphere)
 
-        # Geometric critical angle (straight line, no bending) approximation evaluated at the station depth using the local
-        # index of refraction that defines the direction from which a critically refracted ray would
-        # arrive at the station.
         crit_elev_deg = float(self.get_critical_angle())
 
-        # Convert the local elevation to the angle convention required by the
-        # AraSim ray tracer. This direction is used as the initial launch angle
-        # at the station for the full ray-traced propagation in n(z).
-        crit_rt_angle = np.deg2rad(90.0 - crit_elev_deg)
+        # Convert elevation to AraSim launch angle convention (theta from +z axis, radians):
+        # elevation = 90 - theta; so,  theta = 90 - elevation
+        theta_launch  = np.deg2rad(90.0 - crit_elev_deg)
 
-        allowed_used = int(ROOT.RayTrace.SurfaceReflection)
+        # Choose a far-enough target so the traced path develops its turning point ---
+        # Trace outward well beyond the sphere (10*R) and also enforce a minimum (2000 m)
+        # to ensure robust sampling even for small R.
 
-        # Initialize the ray tracer at the station depth (z_rec). Although the
-        # critical angle is defined for a ray approaching the surface from below,
-        # we launch the ray outward from the station using the same direction.
-        # By ray-path reversibility, this outward trajectory is equivalent to
-        # the time-reversed incoming critical ray and therefore traces the same
-        # physical path through the medium.
-        #
-        # The target is placed slightly above the surface to ensure that the ray
-        # is allowed to continue through the ice-air interface rather than
-        # effectively stopping at z = 0.
-        r_target = float(R + 50.0)
-        z_target = 0.050  # in meters; slightly above the ice surface
+        r_target = max(10.0 * R, 2000.0)
+        z_target = z_rec 
 
+        #Run AraSim tracer from station outward and save all sampled points 
         sol_error = ctypes.c_int(0)
         ROOT.rt_doTrace_savePoints(
             z_rec,
-            float(crit_rt_angle),
-            ROOT.RayTrace.rayTargetRecord(z_target, r_target),
-            allowed_used,
+            float(theta_launch), # launch angle (rad)
+            ROOT.RayTrace.rayTargetRecord(z_target, r_target), # outward target (z, r)
+            int(ROOT.RayTrace.SurfaceReflection),
             float(frequency),
             float(polarization),
             sol_error,
         )
 
+        # Retrieve sampled ray points from the AraSim helper buffers.
         xs = np.asarray(list(ROOT.rt_get_x()), dtype=float)
         zs = np.asarray(list(ROOT.rt_get_z()), dtype=float)
 
+        # Fallback: if trace failed or produced too few points, return geometric critical angle
+        # this has not been observed, but we keep it as a safeguard
         if sol_error.value != 0 or len(xs) < 2:
-            print(
-                f"[CRITICAL ANGLE RT FAIL] forward trace failed: "
-                f"sol_error={sol_error.value}, npts={len(xs)}"
+            print("[CRIT] Trace failed -> geometric fallback")
+            return crit_elev_deg
+
+        # Identify the turning point (maximum z along the trajectory)
+        # Turning point is detected by slope sign change: dz/ds goes from + to -.
+        turning_idx = None
+        for i in range(1, len(xs) - 1):
+            if (zs[i] - zs[i-1]) >= 0 and (zs[i+1] - zs[i]) <= 0:
+                turning_idx = i
+                break
+
+        # If no turning point is found, we cannot define the critical ray reliably fallback.
+        # this has not been observed, but we keep it as a safeguard
+        if turning_idx is None:
+            print("[CRIT] No turning point found -> geometric fallback")
+            return crit_elev_deg
+        # Compute vertical offset of turning point relative to station 
+        z_turn = zs[turning_idx]
+        dz_h   = z_turn - z_rec # dz at the turning point (m)
+
+        # Determine intersection with reconstruction circle rho^2 + dz^2 = R^2
+        if abs(dz_h) < R:
+            # If the turning point lies inside the circle vertically, the circle is intersected
+            # on the upward-going leg at dz=dz_h; solve rho from rho = sqrt(R^2 - dz^2).
+            xp_c  = np.sqrt(R**2 - dz_h**2)
+            dz_c  = dz_h
+        else:
+            # Otherwise, find the exact segment-wise intersection using samples up to the turning point.
+            inter, _ = self._find_sphere_crossing_exact(
+                xs[:turning_idx+1],
+                zs[:turning_idx+1],
+                z_rec,
+                R,
             )
-            return float(self.get_critical_angle())
+            # If no intersection is found (unlikely), fall back to geometric critical angle.
+            if inter is None:
+                return crit_elev_deg
+            xp_c, dz_c = inter
 
-        # Outward traces from the station are ordered station -> outward,
-        # so we search forward for the first inside->outside crossing.
-        inter, i_cross = self._find_sphere_crossing_from_samples(
-            xs,
-            zs,
-            z_rec,
-            R,
-            reverse_search=False,
-        )
-
-        if inter is None:
-            print(
-                f"[CRITICAL ANGLE RT FAIL] no valid RT crossing to "
-                f"R_sphere={R:.3f} m  critical_elevation={crit_elev_deg:.3f} deg"
-            )
-            return float(self.get_critical_angle())
-
-        x_cross, z_cross, _ = inter
-        elev = float(np.degrees(np.arctan2(z_cross, x_cross)))
-
-        if not (-90.0 <= elev <= 90.0):
-            print(
-                f"[CRITICAL ANGLE RT WARN] mapped elevation {elev:.3f} deg outside [-90, 90]; "
-                f"falling back to geometric critical angle with Straight Line approximation"
-            )
-            return float(self.get_critical_angle())
-
+        # Convert the crossing point (rho_cross, dz_cross) to elevation angle (degrees)
+        elev = float(np.degrees(np.arctan2(dz_c, xp_c)))
         return elev
 
+
+    
 
     def get_known_landmarks(
         self,
@@ -1067,9 +1140,9 @@ class AraGeom:
         list_of_cal_pulser_indices=None,
         spice_depth=None,
         solution=None,
-    ):
+        ):
         """
-        Compute apparent directions of known landmarks on a reconstruction sphere.
+        Compute apparent directions of known landmarks on a reconstruction sphere of chosen radius R_map
 
         Each landmark is ray traced to the station and its direction is mapped onto
         the reconstruction sphere of radius R_map. The ray tracer (AraSim findPaths)
@@ -1084,19 +1157,19 @@ class AraGeom:
 
         Fallback rules:
           - D solution: shown unless the ray-traced samples do not yield a valid
-            crossing on R_map. In that case, the same branch is re-traced outward
+            crossing on R_map (source is inside R_map). 
+            In that case, the same branch is re-traced outward
             from the station using AraSim, and the crossing is determined from
             those traced samples. Falls back to straight-line (SL) only if no valid
             RT crossing survives, or if the mapped RT elevation is unphysical for
-            plotting.
+            plotting. We always find a D solution for all landmarks in all stations. 
 
           - R solution: shown if findPaths returns at least two solutions and the
             requested reflected / refracted branch yields a valid RT crossing on
-            R_map. Falls back to SL if:
-              (a) only one solution exists, so the R branch is absent,
-              (b) neither the source->station nor the station->outward traced
-                  samples yield a valid crossing on R_map, or
-              (c) the mapped RT elevation is unphysical for plotting.
+            R_map. Falls back to SL if only one solution exists, so the R branch is absent (that is the 
+            case for surface landmarks where we get SL fallback since AraSim returned only 1 solution 
+            for surface landmarks)
+              
 
         Parameters
         ----------
@@ -1129,6 +1202,8 @@ class AraGeom:
                                       onto R_map, in degrees
               - '_marker_status'    : plotting status for each landmark
         """
+        
+        
         if R_map is None:
             raise ValueError("R_map must be provided to get_known_landmarks().")
         if R_map <= 0:
@@ -1137,8 +1212,7 @@ class AraGeom:
         if list_of_landmarks is None:
             list_of_landmarks = ["IC22S", "ICL", "SPRESSO"]
         elif list_of_landmarks == ["all"]:
-            list_of_landmarks = ["ICL", "IC22S", "IC1S", "WT", "SPRESSO"] #"SPT" removed due to depth of SPT bug in AraRoot 
-
+            list_of_landmarks = ["ICL", "IC22S", "IC1S", "WT", "SPRESSO", "SPT"]
         if list_of_cal_pulser_indices is None:
             list_of_cal_pulser_indices = [1, 3]
         elif list_of_cal_pulser_indices == ["all"]:
@@ -1152,6 +1226,7 @@ class AraGeom:
         station_center = self.get_station_center()
 
         def _resolve(name, source_xyz, station_center, R_sphere, solution):
+            
             """
             Resolve one landmark to its apparent direction on the reconstruction sphere.
 
@@ -1163,7 +1238,7 @@ class AraGeom:
             Parameters
             ----------
             name : str
-                Landmark label used for diagnostic printing and as the collect key.
+                Landmark label used for the collect key.
             source_xyz : array-like
                 Source position [x, y, z] in station-centric Cartesian coordinates,
                 in meters.
@@ -1173,7 +1248,7 @@ class AraGeom:
             R_sphere : float
                 Reconstruction sphere radius, in meters.
             solution : int
-                0 = direct path, 1 = reflected path.
+                0 = direct path, 1 = second-shortest TOF path ('R')
 
             Returns
             -------
@@ -1182,6 +1257,7 @@ class AraGeom:
                 meters, and elevation / azimuth are in degrees. Ray-traced if
                 successful, straight-line fallback otherwise.
             """
+
             r_sl, elev_sl, az_sl = self.get_relative_cartesian_to_spherical(
                 station_center, source_xyz
             )
@@ -1206,6 +1282,7 @@ class AraGeom:
             return [r_sl, rt_sols[0]["elevation"], rt_sols[0]["azimuth"]]
 
         # Local calpulsers
+        
         calpulser = self.get_local_CP(list_of_cal_pulser_indices)
         for cp in calpulser:
             collect[f"CP{cp}"] = _resolve(f"CP{cp}", calpulser[cp], station_center, R_map, solution)
@@ -1218,16 +1295,21 @@ class AraGeom:
                 collect[pulser] = _resolve(pulser, this_pulser, station_center, R_map, solution)
 
         # South Pole surface landmarks
-        for known_loc in ["ICL", "WT", "SPRESSO"]: #"SPT" removed because of unknown depth, AraRoot SPT depth entry is incorrect 
+        
+        for known_loc in ["ICL", "WT", "SPRESSO", "SPT"]:
             if known_loc in list_of_landmarks:
                 this_loc = np.array(self.get_southpole_landmarks(known_loc))[0]
-                st_centric = self.get_global_to_station_centric(this_loc[:3])
-                #if known_loc == "SPT":
-                #    st_centric[2] = 7.55984245e-02  # SPT is removed from surface landmark list due to depth bug in AraRoot
+                st_centric = self.get_global_to_station_centric(this_loc)
                 collect[known_loc] = _resolve(known_loc, st_centric, station_center, R_map, solution)
 
         # Ray-traced critical angle
-        collect["critical_angle_rt"] = self.get_raytraced_critical_angle(R_map)
+        
+        critical_angle_rt = self.get_raytraced_critical_angle(R_map)
+        collect["critical_angle_rt"] = critical_angle_rt
         collect["_marker_status"] = marker_status
 
         return collect
+
+
+
+


### PR DESCRIPTION
Changes made in this PR (I keep the other branch open for now, so we can check if anything I missed, I will delete the previous branch later). 

1. Implementation now follows the AraSim convention for identifying ray solutions: solutions are ordered by propagation time, with the shortest time corresponding to the Direct (D) solution and the second shortest corresponding to the Refracted (R) solution. 

2. The code performs a single ray-tracing call (using `SurfaceReflection`, Changed from `AllReflections` to `SurfaceReflection`) and determines the solution type from the propagation time ordering. The reconstruction-sphere radius is selected based on the map_type, and unnecessary fallback logic from the previous implementation has been removed to keep the behavior consistent with AraSim.
3. Following @marcomuzio 's  excellent suggestion, the critical angle line on the sky map now accounts for ray bending through the ice. 
4. I added docstrings to clarify the logic and flow of the implementation. This may be more documentation than strictly necessary; if preferred, I can trim some of the inline comments later. 

See FiveStation open PR for plots 
