### PR TITLE
Changed ray trace table dir and included systematics in standard reco.

### DIFF
--- a/araproc/analysis/__init__.py
+++ b/araproc/analysis/__init__.py
@@ -7,7 +7,7 @@ ray_trace_tables_dir = os.getenv('RAY_TRACE_TABLES', None)
 
 # If the environment variable is not set, use a default
 if not ray_trace_tables_dir:
-    ray_trace_tables_dir = "/data/ana/ARA/processing/support/raytrace_timing_tables/"
+    ray_trace_tables_dir = "/cvmfs/ara.opensciencegrid.org/data/raytrace_tables/"
     warnings.warn(
         "The 'RAY_TRACE_TABLES' environment variable is not set and will use default: "
         + ray_trace_tables_dir

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -40,7 +40,7 @@ class StandardReco:
         The list of channels you want *exclued* from the interferometry
     station_id : int
         The id of the station you want to reco (only station 1-5 supported)
-    systematics : int
+    icemodel : int
         Which ray trace tables to be used. 40 is nominal, 41 is up, 42 is down.
     requested_maps : set of strings
         The keys for the reco maps to be generated.
@@ -79,7 +79,7 @@ class StandardReco:
                  station_id : int,
                  excluded_channels = np.array([]), # by default no excluded channels
                  requested_maps = const.all_reco_result_maps, # by default create all maps
-                 systematics = 40, # default to using nominal ray tracing tables
+                 icemodel = 40, # default to using nominal ray tracing tables
                 ):
         
         if station_id not in const.valid_station_ids:
@@ -119,10 +119,10 @@ class StandardReco:
 
         # always add a "nearby" correlator for 41m away
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "nearby",
                 radius=float(const.calpulser_r_library[station_id]),
@@ -132,10 +132,10 @@ class StandardReco:
 
         # always add a "distant" correlator for (145m or 300m) away
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "distant",
                 radius=float(const.distant_events_r_library[station_id]),

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -40,6 +40,8 @@ class StandardReco:
         The list of channels you want *exclued* from the interferometry
     station_id : int
         The id of the station you want to reco (only station 1-5 supported)
+    systematics : int
+        Which ray trace tables to be used. 40 is nominal, 41 is up, 42 is down.
     requested_maps : set of strings
         The keys for the reco maps to be generated.
     uncalculated_maps : set of strings
@@ -77,6 +79,7 @@ class StandardReco:
                  station_id : int,
                  excluded_channels = np.array([]), # by default no excluded channels
                  requested_maps = const.all_reco_result_maps, # by default create all maps
+                 systematics = 40, # default to using nominal ray tracing tables
                 ):
         
         if station_id not in const.valid_station_ids:
@@ -113,12 +116,13 @@ class StandardReco:
 
         self.rtc_wrapper = interf.RayTraceCorrelatorWrapper(self.station_id)
 
+
         # always add a "nearby" correlator for 41m away
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "nearby",
                 radius=float(const.calpulser_r_library[station_id]),
@@ -128,10 +132,10 @@ class StandardReco:
 
         # always add a "distant" correlator for (145m or 300m) away
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_40_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.systematics}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "distant",
                 radius=float(const.distant_events_r_library[station_id]),

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -85,6 +85,8 @@ class StandardReco:
         if station_id not in const.valid_station_ids:
             raise KeyError(f"Station {station_id} is not supported")
         self.station_id = station_id
+
+        self.icemodel = icemodel
     
         if not isinstance(excluded_channels, np.ndarray):
             raise KeyError(f"Excluded channel list needs to be a 1D numpy array")
@@ -118,12 +120,20 @@ class StandardReco:
 
 
         # always add a "nearby" correlator for 41m away
+       # dir_path = os.path.join(ray_trace_tables_dir,
+       #                         f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+       #                         )
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0.root"
                                 )
+
+       # ref_path = os.path.join(ray_trace_tables_dir,
+       #                         f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+       #                         )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1.root"
                                 )
+
         self.rtc_wrapper.add_rtc(ref_name = "nearby",
                 radius=float(const.calpulser_r_library[station_id]),
                 path_to_dir_file=dir_path,
@@ -131,11 +141,17 @@ class StandardReco:
                 )
 
         # always add a "distant" correlator for (145m or 300m) away
+        #dir_path = os.path.join(ray_trace_tables_dir,
+        #                        f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+        #                        )
+        #ref_path = os.path.join(ray_trace_tables_dir,
+        #                        f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+        #                        )
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0.root"
                                 )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "distant",
                 radius=float(const.distant_events_r_library[station_id]),

--- a/araproc/analysis/standard_reco.py
+++ b/araproc/analysis/standard_reco.py
@@ -120,20 +120,12 @@ class StandardReco:
 
 
         # always add a "nearby" correlator for 41m away
-       # dir_path = os.path.join(ray_trace_tables_dir,
-       #                         f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
-       #                         )
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
-
-       # ref_path = os.path.join(ray_trace_tables_dir,
-       #                         f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
-       #                         )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.calpulser_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
-
         self.rtc_wrapper.add_rtc(ref_name = "nearby",
                 radius=float(const.calpulser_r_library[station_id]),
                 path_to_dir_file=dir_path,
@@ -141,17 +133,11 @@ class StandardReco:
                 )
 
         # always add a "distant" correlator for (145m or 300m) away
-        #dir_path = os.path.join(ray_trace_tables_dir,
-        #                        f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
-        #                        )
-        #ref_path = os.path.join(ray_trace_tables_dir,
-        #                        f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
-        #                        )
         dir_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_0_v2.root"
                                 )
         ref_path = os.path.join(ray_trace_tables_dir,
-                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1.root"
+                                f"arrivaltimes_station_{self.station_id}_icemodel_{self.icemodel}_radius_{const.distant_events_r_library[station_id]}_angle_1.00_solution_1_v2.root"
                                 )
         self.rtc_wrapper.add_rtc(ref_name = "distant",
                 radius=float(const.distant_events_r_library[station_id]),


### PR DESCRIPTION
Sets a new default directory for the ray trace tables. This also adds an argument for the standard_reco class for the systematics, so in fivestation we'll need to specify 41 (up) or 42 (down) if we want to run with the ice model systematics on.