### PR TITLE
Add trig receipt

### DIFF
--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -164,14 +164,13 @@ def find_best_triggering_antenna(report_station, detector_station):
     # return the triggering antenna with the greatest SNR
     return best_ant
 
-def find_avg_receipt_ang(report_station, detector_station):
+def find_avg_receipt_ang(report_station):
     """
     Calculate the average receiving angle of the signal by the antennas. 
 
     Parameters
     ----------
     report_station : ROOT AraSim Report::StationReport object (i.e. report.stations[0])
-    detector_station : ROOT AraSim Detector::ARA_station object (i.e. detector.stations[0])
 
     Returns
     -------
@@ -179,20 +178,8 @@ def find_avg_receipt_ang(report_station, detector_station):
         Average zenith angle (measured from nadir = 0) of signal seen by triggered antennas.
     """
 
-    # find all antennas that participated in the trigger
-    trig_ants = [
-        (s, a)
-        for s in range(len(report_station.strings))
-        for a in range(len(report_station.strings[s].antennas))
-        if report_station.strings[s].antennas[a].Trig_Pass
-    ]
-
-    # if the event doesn't trigger, put a sentinel to mark it
-    # a very negative value will also fail any rec ang cut so it isn't mistakenly counted
-    if len(trig_ants) == 0:
-        return -1000 
-
-    avg_rec_ang = np.mean(report_station.strings[s].antennas[a].theta_rec for s, a in trig_ants)
+    rec_angs = [report_station.strings[s].antennas[a].theta_rec for s in report_station.strings for a in report_station.strings[s].antennas[a]]
+    avg_rec_ang = np.mean(rec_angs)
 
     return avg_rec_ang
 
@@ -1051,7 +1038,7 @@ class SimWrapper:
         sim_info["is_noise"] = (int(self.settings_ptr.TRIG_ANALYSIS_MODE) == 2) # modes 0 & 1 are for signal, 2 is pure noise
 
         # get the receipt angle for the triggered antennas
-        sim_info["avg_rec_ang"] = self.find_avg_receipt_ang(self.report_ptr, self.detector_ptr)
+        sim_info["avg_rec_ang"] = self.find_avg_receipt_ang(self.report_ptr)
 
         return sim_info
     

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -1049,7 +1049,7 @@ class SimWrapper:
         sim_info["is_noise"] = (int(self.settings_ptr.TRIG_ANALYSIS_MODE) == 2) # modes 0 & 1 are for signal, 2 is pure noise
 
         # get the receipt angle for the triggered antennas
-        sim_info["rec_ang"] = self.find_avg_receipt_ang(self.report_ptr, self.detector_ptr)
+        sim_info["avg_rec_ang"] = self.find_avg_receipt_ang(self.report_ptr, self.detector_ptr)
 
         return sim_info
     

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -175,7 +175,7 @@ def find_avg_receipt_ang(report_station):
     Returns
     -------
     avg_rec_ang : float
-        Average zenith angle (measured from nadir = 0) of signal seen by triggered antennas.
+        Average zenith angle in radians (measured from nadir = 0) of signal seen by triggered antennas.
     """
 
     rec_angs = [report_station.strings[s].antennas[a].theta_rec for s in report_station.strings for a in report_station.strings[s].antennas[a]]

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -164,6 +164,35 @@ def find_best_triggering_antenna(report_station, detector_station):
     # return the triggering antenna with the greatest SNR
     return best_ant
 
+def find_avg_receipt_ang(report_station, detector_station):
+    """
+    Calculate the average receiving angle of the signal by the antennas. 
+
+    Parameters
+    ----------
+    report_station : ROOT AraSim Report::StationReport object (i.e. report.stations[0])
+    detector_station : ROOT AraSim Detector::ARA_station object (i.e. detector.stations[0])
+
+    Returns
+    -------
+    avg_rec_ang : float
+        Average zenith angle (measured from nadir = 0) of signal seen by triggered antennas.
+    """
+
+    # find all antennas that participated in the trigger
+    trig_ants = [
+        (s, a)
+        for s in range(len(report_station.strings))
+        for a in range(len(report_station.strings[s].antennas))
+        if report_station.strings[s].antennas[a].Trig_Pass
+    ]
+
+    if len(trig_ants) == 0:
+        return -1
+
+    avg_rec_ang = np.mean(report_station.strings[s].antennas[a].theta_rec for s, a in trig_ants)
+
+    return avg_rec_ang
 
 class DataWrapper:
 
@@ -1018,6 +1047,9 @@ class SimWrapper:
         # -1 means a solution was not determined
 
         sim_info["is_noise"] = (int(self.settings_ptr.TRIG_ANALYSIS_MODE) == 2) # modes 0 & 1 are for signal, 2 is pure noise
+
+        # get the receipt angle for the triggered antennas
+        sim_info["rec_ang"] = self.find_avg_receipt_ang(self.report_ptr, self.detector_ptr)
 
         return sim_info
     

--- a/araproc/framework/dataset.py
+++ b/araproc/framework/dataset.py
@@ -187,8 +187,10 @@ def find_avg_receipt_ang(report_station, detector_station):
         if report_station.strings[s].antennas[a].Trig_Pass
     ]
 
+    # if the event doesn't trigger, put a sentinel to mark it
+    # a very negative value will also fail any rec ang cut so it isn't mistakenly counted
     if len(trig_ants) == 0:
-        return -1
+        return -1000 
 
     avg_rec_ang = np.mean(report_station.strings[s].antennas[a].theta_rec for s, a in trig_ants)
 


### PR DESCRIPTION
This adds a helper function for getting the average receipt angle of an event for the antennas that triggered.